### PR TITLE
Fixed compilation errors on linux.

### DIFF
--- a/Modules/CMakeFastbuildFindMake.cmake
+++ b/Modules/CMakeFastbuildFindMake.cmake
@@ -1,0 +1,8 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+
+find_program(CMAKE_MAKE_PROGRAM
+  NAMES fbuild
+  DOC "Program used to build from fastbuild .bff files.")
+mark_as_advanced(CMAKE_MAKE_PROGRAM)

--- a/Modules/CMakeGenericSystem.cmake
+++ b/Modules/CMakeGenericSystem.cmake
@@ -60,6 +60,11 @@ if(CMAKE_GENERATOR MATCHES "Ninja")
   mark_as_advanced(CMAKE_EXPORT_COMPILE_COMMANDS)
 endif()
 
+
+if(CMAKE_GENERATOR MATCHES "Fastbuild")
+  set(CMAKE_NO_BUILD_TYPE 1)
+endif()
+
 # GetDefaultWindowsPrefixBase
 #
 # Compute the base directory for CMAKE_INSTALL_PREFIX based on:

--- a/Modules/ExternalProject.cmake
+++ b/Modules/ExternalProject.cmake
@@ -1249,7 +1249,8 @@ function(_ep_get_build_command name step cmd_var)
         if(CMAKE_CONFIGURATION_TYPES)
           if (CMAKE_CFG_INTDIR AND
               NOT CMAKE_CFG_INTDIR STREQUAL "." AND
-              NOT CMAKE_CFG_INTDIR MATCHES "\\$")
+              NOT CMAKE_CFG_INTDIR MATCHES "\\$" AND
+              NOT CMAKE_CFG_INTDIR MATCHES "FASTBUILD_DOLLAR_TAG")
             # CMake 3.4 and below used the CMAKE_CFG_INTDIR placeholder value
             # provided by multi-configuration generators.  Some projects were
             # taking advantage of that undocumented implementation detail to

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -491,7 +491,9 @@ if (WIN32)
       cmGlobalVisualStudio15Generator.h
       cmGlobalVisualStudio15Generator.cxx
       cmGlobalVisualStudioGenerator.cxx
-      cmGlobalVisualStudioGenerator.h
+      cmGlobalFastbuildGenerator.h
+      cmGlobalFastbuildGenerator.cxx
+      cmGlobalGenerator.h
       cmIDEFlagTable.h
       cmIDEOptions.cxx
       cmIDEOptions.h
@@ -499,6 +501,8 @@ if (WIN32)
       cmLocalVisualStudio7Generator.h
       cmLocalVisualStudioGenerator.cxx
       cmLocalVisualStudioGenerator.h
+      cmLocalFastbuildGenerator.cxx
+      cmLocalFastbuildGenerator.h
       cmVisualStudioSlnData.h
       cmVisualStudioSlnData.cxx
       cmVisualStudioSlnParser.h

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -491,8 +491,6 @@ if (WIN32)
       cmGlobalVisualStudio15Generator.h
       cmGlobalVisualStudio15Generator.cxx
       cmGlobalVisualStudioGenerator.cxx
-      cmGlobalFastbuildGenerator.h
-      cmGlobalFastbuildGenerator.cxx
       cmGlobalGenerator.h
       cmIDEFlagTable.h
       cmIDEOptions.cxx
@@ -501,8 +499,6 @@ if (WIN32)
       cmLocalVisualStudio7Generator.h
       cmLocalVisualStudioGenerator.cxx
       cmLocalVisualStudioGenerator.h
-      cmLocalFastbuildGenerator.cxx
-      cmLocalFastbuildGenerator.h
       cmVisualStudioSlnData.h
       cmVisualStudioSlnData.cxx
       cmVisualStudioSlnParser.h
@@ -552,7 +548,15 @@ set(SRCS ${SRCS}
 # Temporary variable for tools targets
 set(_tools)
 
-if(WIN32 AND NOT CYGWIN)
+# Fastbuild support
+set(SRCS ${SRCS}
+  cmGlobalFastbuildGenerator.h
+  cmGlobalFastbuildGenerator.cxx
+  cmLocalFastbuildGenerator.cxx
+  cmLocalFastbuildGenerator.h
+  )
+
+  if(WIN32 AND NOT CYGWIN)
   set_source_files_properties(cmcldeps.cxx PROPERTIES COMPILE_DEFINITIONS _WIN32_WINNT=0x0501)
   add_executable(cmcldeps cmcldeps.cxx ${MANIFEST_FILE})
   list(APPEND _tools cmcldeps)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -491,6 +491,7 @@ if (WIN32)
       cmGlobalVisualStudio15Generator.h
       cmGlobalVisualStudio15Generator.cxx
       cmGlobalVisualStudioGenerator.cxx
+      cmGlobalVisualStudioGenerator.h
       cmGlobalGenerator.h
       cmIDEFlagTable.h
       cmIDEOptions.cxx
@@ -554,6 +555,8 @@ set(SRCS ${SRCS}
   cmGlobalFastbuildGenerator.cxx
   cmLocalFastbuildGenerator.cxx
   cmLocalFastbuildGenerator.h
+  cmFastbuildTargetGenerator.cxx
+  cmFastbuildTargetGenerator.h
   )
 
   if(WIN32 AND NOT CYGWIN)

--- a/Source/cmFastbuildTargetGenerator.cxx
+++ b/Source/cmFastbuildTargetGenerator.cxx
@@ -1,0 +1,1480 @@
+#include "cmFastbuildTargetGenerator.h"
+
+#include "cmComputeLinkInformation.h"
+#include "cmCustomCommandGenerator.h"
+#include "cmGeneratorTarget.h"
+#include "cmMakefile.h"
+#include "cmSourceFile.h"
+
+#define FASTBUILD_DOLLAR_TAG "FASTBUILD_DOLLAR_TAG"
+
+cmGlobalFastbuildGenerator::Detail::Generation::CustomCommandAliasMap
+  cmFastbuildTargetGenerator::s_customCommandAliases;
+
+cmFastbuildTargetGenerator::cmFastbuildTargetGenerator(cmGeneratorTarget* gt)
+  : cmCommonTargetGenerator(gt)
+  , m_fileContext(((cmGlobalFastbuildGenerator*)GlobalGenerator)->g_fc)
+{
+}
+
+void cmFastbuildTargetGenerator::DetectTargetCompileDependencies(
+  cmGlobalCommonGenerator* gg, std::vector<std::string>& dependencies)
+{
+  if (GeneratorTarget->GetType() == cmState::GLOBAL_TARGET) {
+    // Global targets only depend on other utilities, which may not appear in
+    // the TargetDepends set (e.g. "all").
+    std::set<std::string> const& utils = GeneratorTarget->GetUtilities();
+    std::copy(utils.begin(), utils.end(), std::back_inserter(dependencies));
+  } else {
+    cmTargetDependSet const& targetDeps =
+      gg->GetTargetDirectDepends(GeneratorTarget);
+    for (cmTargetDependSet::const_iterator i = targetDeps.begin();
+         i != targetDeps.end(); ++i) {
+      const cmTargetDepend& depTarget = *i;
+      if (depTarget->GetType() == cmState::INTERFACE_LIBRARY) {
+        continue;
+      }
+      dependencies.push_back(depTarget->GetName());
+    }
+  }
+}
+
+void cmFastbuildTargetGenerator::WriteTargetAliases(
+  const std::vector<std::string>& linkableDeps,
+  const std::vector<std::string>& orderDeps)
+{
+  const std::string& targetName = GeneratorTarget->GetName();
+
+  std::vector<std::string> configs;
+  Makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    const std::string& configName = *iter;
+
+    if (!linkableDeps.empty()) {
+      m_fileContext.WriteCommand(
+        "Alias", cmGlobalFastbuildGenerator::Quote(targetName + "-" +
+                                                   configName + "-products"));
+      m_fileContext.WritePushScope();
+      m_fileContext.WriteArray(
+        "Targets",
+        cmGlobalFastbuildGenerator::Wrap(linkableDeps, "'" + targetName + "-",
+                                         "-" + configName + "'"));
+      m_fileContext.WritePopScope();
+    }
+
+    if (!orderDeps.empty() || !linkableDeps.empty()) {
+      m_fileContext.WriteCommand("Alias", cmGlobalFastbuildGenerator::Quote(
+                                            targetName + "-" + configName));
+      m_fileContext.WritePushScope();
+      m_fileContext.WriteArray(
+        "Targets",
+        cmGlobalFastbuildGenerator::Wrap(linkableDeps, "'" + targetName + "-",
+                                         "-" + configName + "'"));
+      m_fileContext.WriteArray("Targets", cmGlobalFastbuildGenerator::Wrap(
+                                            orderDeps, "'" + targetName + "-",
+                                            "-" + configName + "'"),
+                               "+");
+      m_fileContext.WritePopScope();
+    }
+  }
+}
+
+void cmFastbuildTargetGenerator::WriteCustomBuildSteps(
+  const std::vector<cmCustomCommand>& commands, const std::string& buildStep,
+  const std::vector<std::string>& orderDeps)
+{
+  if (commands.empty()) {
+    return;
+  }
+
+  const std::string& targetName = GeneratorTarget->GetName();
+
+  // Now output the commands
+  std::vector<std::string> configs;
+  Makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    const std::string& configName = *iter;
+
+    m_fileContext.WriteVariable("buildStep_" + buildStep + "_" + configName,
+                                "");
+    m_fileContext.WritePushScopeStruct();
+
+    m_fileContext.WriteCommand("Using", ".BaseConfig_" + configName);
+
+    m_fileContext.WriteArray(
+      "PreBuildDependencies",
+      cmGlobalFastbuildGenerator::Wrap(orderDeps, "'", "-" + configName + "'"),
+      "+");
+
+    std::string baseName = targetName + "-" + buildStep + "-" + configName;
+    int commandCount = 1;
+    std::vector<std::string> customCommandTargets;
+    for (std::vector<cmCustomCommand>::const_iterator ccIter =
+           commands.begin();
+         ccIter != commands.end(); ++ccIter) {
+      const cmCustomCommand& cc = *ccIter;
+
+      std::stringstream customCommandTargetName;
+      customCommandTargetName << baseName << (commandCount++);
+
+      std::string customCommandTargetNameStr = customCommandTargetName.str();
+      WriteCustomCommand(&cc, configName, customCommandTargetNameStr,
+                         targetName);
+      customCommandTargets.push_back(customCommandTargetNameStr);
+    }
+
+    // Write an alias for this object group to group them all together
+    m_fileContext.WriteCommand("Alias",
+                               cmGlobalFastbuildGenerator::Quote(baseName));
+    m_fileContext.WritePushScope();
+    m_fileContext.WriteArray("Targets", cmGlobalFastbuildGenerator::Wrap(
+                                          customCommandTargets, "'", "'"));
+    m_fileContext.WritePopScope();
+
+    m_fileContext.WritePopScope();
+  }
+}
+
+void cmFastbuildTargetGenerator::AddIncludeFlags(std::string& flags,
+                                                 const std::string& lang)
+{
+}
+
+bool cmFastbuildTargetGenerator::WriteCustomBuildRules()
+{
+  bool hasCustomCommands = false;
+  const std::string& targetName = GeneratorTarget->GetName();
+
+  // Iterating over all configurations
+  std::vector<std::string> configs;
+  Makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    std::string configName = *iter;
+
+    m_fileContext.WriteVariable("CustomCommands_" + configName, "");
+    m_fileContext.WritePushScopeStruct();
+
+    m_fileContext.WriteCommand("Using", ".BaseConfig_" + configName);
+
+    // Figure out the list of custom build rules in use by this target
+    // get a list of source files
+    std::vector<cmSourceFile const*> customCommands;
+    GeneratorTarget->GetCustomCommands(customCommands, configName);
+
+    if (!customCommands.empty()) {
+      // Presort the commands to adjust for dependencies
+      // In a number of cases, the commands inputs will be the outputs
+      // from another command. Need to sort the commands to output them in
+      // order.
+      cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
+        CustomCommandHelper ccHelper = { GlobalGenerator, LocalGenerator,
+                                         configName };
+      cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::Sort(
+        ccHelper, customCommands);
+
+      std::vector<std::string> customCommandTargets;
+
+      // Write the custom command build rules for each configuration
+      int commandCount = 1;
+      std::string customCommandNameBase = "CustomCommand-" + configName + "-";
+      for (std::vector<cmSourceFile const*>::iterator ccIter =
+             customCommands.begin();
+           ccIter != customCommands.end(); ++ccIter) {
+        const cmSourceFile* sourceFile = *ccIter;
+
+        std::stringstream customCommandTargetName;
+        customCommandTargetName << customCommandNameBase << (commandCount++);
+        customCommandTargetName
+          << "-" << cmSystemTools::GetFilenameName(sourceFile->GetFullPath());
+        ;
+
+        std::string customCommandTargetNameStr = customCommandTargetName.str();
+        WriteCustomCommand(sourceFile->GetCustomCommand(), configName,
+                           customCommandTargetNameStr, targetName);
+
+        customCommandTargets.push_back(customCommandTargetNameStr);
+      }
+
+      std::string customCommandGroupName =
+        targetName + "-CustomCommands-" + configName;
+
+      // Write an alias for this object group to group them all together
+      m_fileContext.WriteCommand(
+        "Alias", cmGlobalFastbuildGenerator::Quote(customCommandGroupName));
+      m_fileContext.WritePushScope();
+      m_fileContext.WriteArray("Targets", cmGlobalFastbuildGenerator::Wrap(
+                                            customCommandTargets, "'", "'"));
+      m_fileContext.WritePopScope();
+
+      // Now make everything use this as prebuilt dependencies
+      std::vector<std::string> tmp;
+      tmp.push_back(customCommandGroupName);
+      m_fileContext.WriteArray("PreBuildDependencies",
+                               cmGlobalFastbuildGenerator::Wrap(tmp), "+");
+
+      hasCustomCommands = true;
+    }
+
+    m_fileContext.WritePopScope();
+  }
+
+  return hasCustomCommands;
+}
+
+void cmFastbuildTargetGenerator::WriteCustomCommand(
+  const cmCustomCommand* cc, const std::string& configName,
+  std::string& targetName, const std::string& hostTargetName)
+{
+  // We need to generate the command for execution.
+  cmCustomCommandGenerator ccg(*cc, configName, LocalGenerator);
+
+  const std::vector<std::string>& outputs = ccg.GetOutputs();
+  const std::vector<std::string>& byproducts = ccg.GetByproducts();
+  std::vector<std::string> mergedOutputs;
+  mergedOutputs.insert(mergedOutputs.end(), outputs.begin(), outputs.end());
+  mergedOutputs.insert(mergedOutputs.end(), byproducts.begin(),
+                       byproducts.end());
+
+  // TODO: Double check that none of the outputs are 'symbolic'
+  // In which case, FASTBuild won't want them treated as
+  // outputs.
+  {
+    // Loop through all outputs, and attempt to find it in the
+    // source files.
+    for (size_t index = 0; index < mergedOutputs.size(); ++index) {
+      const std::string& outputName = mergedOutputs[index];
+
+      cmSourceFile* outputSourceFile = Makefile->GetSource(outputName);
+      // Check if this file is symbolic
+      if (outputSourceFile &&
+          outputSourceFile->GetPropertyAsBool("SYMBOLIC")) {
+        // We need to remove this file from the list of outputs
+        // Swap with back and pop
+        mergedOutputs[index] = mergedOutputs.back();
+        mergedOutputs.pop_back();
+      }
+    }
+  }
+
+  std::vector<std::string> inputs;
+  std::vector<std::string> orderDependencies;
+
+  // If this exec node always generates outputs,
+  // then we need to make sure we don't define outputs multiple times.
+  // but if the command should always run (i.e. post builds etc)
+  // then we will output a new one.
+  if (!mergedOutputs.empty()) {
+    // Check if this custom command has already been output.
+    // If it has then just drop an alias here to the original
+    cmGlobalFastbuildGenerator::Detail::Generation::CustomCommandAliasMap::
+      iterator findResult = s_customCommandAliases.find(cc);
+    if (findResult != s_customCommandAliases.end()) {
+      const std::set<std::string>& aliases = findResult->second;
+      if (aliases.find(targetName) != aliases.end()) {
+        // This target has already been generated
+        // with the correct name somewhere else.
+        return;
+      }
+      if (!isConfigDependant(&ccg)) {
+        // This command has already been generated.
+        // But under a different name so setup an alias to redirect
+        // No merged outputs, so this command must always be run.
+        // Make it's name unique to its host target
+        targetName += "-";
+        targetName += hostTargetName;
+
+        std::vector<std::string> targets;
+        targets.push_back(*findResult->second.begin());
+
+        m_fileContext.WriteCommand(
+          "Alias", cmGlobalFastbuildGenerator::Quote(targetName));
+        m_fileContext.WritePushScope();
+        {
+          m_fileContext.WriteArray("Targets",
+                                   cmGlobalFastbuildGenerator::Wrap(targets));
+        }
+        m_fileContext.WritePopScope();
+        return;
+      }
+    }
+    s_customCommandAliases[cc].insert(targetName);
+  } else {
+    // No merged outputs, so this command must always be run.
+    // Make it's name unique to its host target
+    targetName += "-";
+    targetName += hostTargetName;
+  }
+
+  // Take the dependencies listed and split into targets and files.
+  const std::vector<std::string>& depends = ccg.GetDepends();
+  for (std::vector<std::string>::const_iterator iter = depends.begin();
+       iter != depends.end(); ++iter) {
+    const std::string& dep = *iter;
+
+    bool isTarget = GlobalGenerator->FindTarget(dep) != NULL;
+    if (isTarget) {
+      orderDependencies.push_back(dep + "-" + configName);
+    } else {
+      inputs.push_back(dep);
+    }
+  }
+
+#ifdef _WIN32
+  const std::string shellExt = ".bat";
+#else
+  const std::string shellExt = ".sh";
+#endif
+
+  std::string workingDirectory = ccg.GetWorkingDirectory();
+  if (workingDirectory.empty()) {
+    workingDirectory = Makefile->GetCurrentBinaryDirectory();
+    workingDirectory += "/";
+  }
+
+  std::string scriptFileName(workingDirectory + targetName + ".bat");
+  cmsys::ofstream scriptFile(scriptFileName.c_str());
+
+  for (unsigned i = 0; i != ccg.GetNumberOfCommands(); ++i) {
+    std::string args;
+    ccg.AppendArguments(i, args);
+    cmSystemTools::ReplaceString(args, "$$", "$");
+    cmSystemTools::ReplaceString(args, FASTBUILD_DOLLAR_TAG, "$");
+#ifdef _WIN32
+    // in windows batch, '%' is a special character that needs to be doubled
+    // to be escaped
+    cmSystemTools::ReplaceString(args, "%", "%%");
+#endif
+    ResolveFastbuildVariables(args, configName);
+
+    std::string command(ccg.GetCommand(i));
+    cmSystemTools::ReplaceString(command, FASTBUILD_DOLLAR_TAG, "$");
+    ResolveFastbuildVariables(command, configName);
+
+    scriptFile << cmGlobalFastbuildGenerator::Quote(command, "\"") << args
+               << std::endl;
+  }
+
+  // Write out an exec command
+  /*
+  Exec(alias); (optional)Alias
+  {
+      .ExecExecutable; Executable to run
+      .ExecInput; Input file to pass to executable
+      .ExecOutput; Output file generated by executable
+      .ExecArguments; (optional)Arguments to pass to executable
+      .ExecWorkingDir; (optional)Working dir to set for executable
+
+      ; Additional options
+      .PreBuildDependencies; (optional)Force targets to be built before this
+  Exec(Rarely needed,
+      ; but useful when Exec relies on externally generated files).
+  }
+  */
+
+  std::for_each(inputs.begin(), inputs.end(), &UnescapeFastbuildVariables);
+  std::for_each(mergedOutputs.begin(), mergedOutputs.end(),
+                &UnescapeFastbuildVariables);
+
+  m_fileContext.WriteCommand("Exec",
+                             cmGlobalFastbuildGenerator::Quote(targetName));
+  m_fileContext.WritePushScope();
+  {
+#ifdef _WIN32
+    m_fileContext.WriteVariable("ExecExecutable",
+                                cmGlobalFastbuildGenerator::Quote(
+                                  cmSystemTools::FindProgram("cmd.exe")));
+    m_fileContext.WriteVariable(
+      "ExecArguments",
+      cmGlobalFastbuildGenerator::Quote("/C " + scriptFileName));
+#else
+    context.fc.WriteVariable("ExecExecutable", Quote(scriptFileName));
+#endif
+    if (!workingDirectory.empty()) {
+      m_fileContext.WriteVariable(
+        "ExecWorkingDir", cmGlobalFastbuildGenerator::Quote(workingDirectory));
+    }
+
+    if (inputs.empty()) {
+      // inputs.push_back("dummy-in");
+    }
+    m_fileContext.WriteArray("ExecInput",
+                             cmGlobalFastbuildGenerator::Wrap(inputs));
+
+    if (mergedOutputs.empty()) {
+      m_fileContext.WriteVariable("ExecUseStdOutAsOutput", "true");
+
+      std::string outputDir =
+        LocalGenerator->GetMakefile()->GetHomeOutputDirectory();
+      mergedOutputs.push_back(outputDir + "/dummy-out-" + targetName + ".txt");
+    }
+    // Currently fastbuild doesn't support more than 1
+    // output for a custom command (soon to change hopefully).
+    // so only use the first one
+    m_fileContext.WriteVariable(
+      "ExecOutput", cmGlobalFastbuildGenerator::Quote(mergedOutputs[0]));
+  }
+  m_fileContext.WritePopScope();
+}
+
+void cmFastbuildTargetGenerator::DetectOutput(
+  FastbuildTargetNames& targetNamesOut, const std::string& configName)
+{
+  if (GeneratorTarget->GetType() == cmState::EXECUTABLE) {
+    GeneratorTarget->GetExecutableNames(
+      targetNamesOut.targetNameOut, targetNamesOut.targetNameReal,
+      targetNamesOut.targetNameImport, targetNamesOut.targetNamePDB,
+      configName);
+  } else {
+    GeneratorTarget->GetLibraryNames(
+      targetNamesOut.targetNameOut, targetNamesOut.targetNameSO,
+      targetNamesOut.targetNameReal, targetNamesOut.targetNameImport,
+      targetNamesOut.targetNamePDB, configName);
+  }
+
+  if (GeneratorTarget->HaveWellDefinedOutputFiles()) {
+    targetNamesOut.targetOutputDir =
+      GeneratorTarget->GetSupportDirectory() + "/";
+
+    targetNamesOut.targetOutput = GeneratorTarget->GetFullPath(configName);
+    targetNamesOut.targetOutputReal =
+      GeneratorTarget->GetFullPath(configName,
+                                   /*implib=*/false,
+                                   /*realpath=*/true);
+    targetNamesOut.targetOutputImplib =
+      GeneratorTarget->GetFullPath(configName,
+                                   /*implib=*/true);
+  } else {
+    targetNamesOut.targetOutputDir = GeneratorTarget->GetSupportDirectory();
+    if (targetNamesOut.targetOutputDir.empty() ||
+        targetNamesOut.targetOutputDir == ".") {
+      targetNamesOut.targetOutputDir = GeneratorTarget->GetName();
+    } else {
+      targetNamesOut.targetOutputDir += "/";
+      targetNamesOut.targetOutputDir += GeneratorTarget->GetName();
+    }
+    targetNamesOut.targetOutputDir += "/";
+    targetNamesOut.targetOutputDir += configName;
+    targetNamesOut.targetOutputDir += "/";
+
+    targetNamesOut.targetOutput =
+      targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameOut;
+    targetNamesOut.targetOutputImplib =
+      targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameImport;
+    targetNamesOut.targetOutputReal =
+      targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameReal;
+  }
+
+  if (GeneratorTarget->GetType() == cmState::EXECUTABLE ||
+      GeneratorTarget->GetType() == cmState::STATIC_LIBRARY ||
+      GeneratorTarget->GetType() == cmState::SHARED_LIBRARY ||
+      GeneratorTarget->GetType() == cmState::MODULE_LIBRARY) {
+    targetNamesOut.targetOutputPDBDir =
+      GeneratorTarget->GetPDBDirectory(configName);
+    targetNamesOut.targetOutputPDBDir += "/";
+  }
+  if (GeneratorTarget->GetType() <= cmState::OBJECT_LIBRARY) {
+    targetNamesOut.targetOutputCompilePDBDir =
+      GeneratorTarget->GetCompilePDBPath(configName);
+    if (targetNamesOut.targetOutputCompilePDBDir.empty()) {
+      targetNamesOut.targetOutputCompilePDBDir =
+        GeneratorTarget->GetSupportDirectory() + "/";
+    }
+  }
+
+  // Make sure all obey the correct slashes
+  cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutput);
+  cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputImplib);
+  cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputReal);
+  cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputDir);
+  cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputPDBDir);
+  cmSystemTools::ConvertToOutputSlashes(
+    targetNamesOut.targetOutputCompilePDBDir);
+}
+
+void cmFastbuildTargetGenerator::DetectLinkerLibPaths(
+  std::string& linkerLibPath, const std::string& configName)
+{
+  cmComputeLinkInformation* pcli =
+    GeneratorTarget->GetLinkInformation(configName);
+  if (!pcli) {
+    // No link information, then no linker library paths
+    return;
+  }
+  cmComputeLinkInformation& cli = *pcli;
+
+  std::string libPathFlag =
+    Makefile->GetRequiredDefinition("CMAKE_LIBRARY_PATH_FLAG");
+  std::string libPathTerminator =
+    Makefile->GetSafeDefinition("CMAKE_LIBRARY_PATH_TERMINATOR");
+
+  // Append the library search path flags.
+  std::vector<std::string> const& libDirs = cli.GetDirectories();
+  for (std::vector<std::string>::const_iterator libDir = libDirs.begin();
+       libDir != libDirs.end(); ++libDir) {
+    std::string libpath = LocalGenerator->ConvertToOutputForExisting(
+      *libDir, cmLocalGenerator::SHELL);
+    cmSystemTools::ConvertToOutputSlashes(libpath);
+
+    // Add the linker lib path twice, once raw, then once with
+    // the configname attached
+    std::string configlibpath = libpath + "/" + configName;
+    cmSystemTools::ConvertToOutputSlashes(configlibpath);
+
+    linkerLibPath += " " + libPathFlag;
+    linkerLibPath += libpath;
+    linkerLibPath += libPathTerminator;
+
+    linkerLibPath += " " + libPathFlag;
+    linkerLibPath += configlibpath;
+    linkerLibPath += libPathTerminator;
+    linkerLibPath += " ";
+  }
+}
+
+bool cmFastbuildTargetGenerator::DetectBaseLinkerCommand(
+  std::string& command, const std::string& configName)
+{
+  const std::string& linkLanguage =
+    GeneratorTarget->GetLinkerLanguage(configName);
+  if (linkLanguage.empty()) {
+    cmSystemTools::Error("CMake can not determine linker language for "
+                         "target: ",
+                         GeneratorTarget->GetName().c_str());
+    return false;
+  }
+
+  this->GeneratorTarget->GetLinkInformation(this->GetConfigName());
+
+  cmLocalGenerator::RuleVariables vars;
+  vars.RuleLauncher = "RULE_LAUNCH_LINK";
+  vars.CMTarget = GeneratorTarget;
+  vars.Language = linkLanguage.c_str();
+  const std::string manifests = this->GetManifests();
+  vars.Manifests = manifests.c_str();
+
+  std::string responseFlag;
+  vars.Objects =
+    FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+  vars.LinkLibraries = "";
+
+  vars.ObjectDir = FASTBUILD_DOLLAR_TAG "TargetOutDir" FASTBUILD_DOLLAR_TAG;
+  vars.Target =
+    FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+
+  vars.TargetSOName = FASTBUILD_DOLLAR_TAG "TargetOutSO" FASTBUILD_DOLLAR_TAG;
+  vars.TargetPDB = FASTBUILD_DOLLAR_TAG
+    "TargetOutPDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
+    "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
+
+  // Setup the target version.
+  std::string targetVersionMajor;
+  std::string targetVersionMinor;
+  {
+    std::ostringstream majorStream;
+    std::ostringstream minorStream;
+    int major;
+    int minor;
+    GeneratorTarget->GetTargetVersion(major, minor);
+    majorStream << major;
+    minorStream << minor;
+    targetVersionMajor = majorStream.str();
+    targetVersionMinor = minorStream.str();
+  }
+  vars.TargetVersionMajor = targetVersionMajor.c_str();
+  vars.TargetVersionMinor = targetVersionMinor.c_str();
+
+  vars.Defines =
+    FASTBUILD_DOLLAR_TAG "CompileDefineFlags" FASTBUILD_DOLLAR_TAG;
+  vars.Flags = FASTBUILD_DOLLAR_TAG "TargetFlags" FASTBUILD_DOLLAR_TAG;
+  vars.LinkFlags = FASTBUILD_DOLLAR_TAG "LinkFlags" FASTBUILD_DOLLAR_TAG
+                                        " " FASTBUILD_DOLLAR_TAG
+                                        "LinkPath" FASTBUILD_DOLLAR_TAG;
+  // Rule for linking library/executable.
+  std::vector<std::string> linkCmds;
+  ComputeLinkCmds(linkCmds, configName);
+  for (std::vector<std::string>::iterator i = linkCmds.begin();
+       i != linkCmds.end(); ++i) {
+    ((cmLocalFastbuildGenerator*)LocalGenerator)
+      ->ExpandRuleVariables(*i, vars);
+  }
+
+  command = BuildCommandLine(linkCmds);
+
+  return true;
+}
+
+void cmFastbuildTargetGenerator::ComputeLinkCmds(
+  std::vector<std::string>& linkCmds, std::string configName)
+{
+  const std::string& linkLanguage =
+    GeneratorTarget->GetLinkerLanguage(configName);
+  {
+    std::string linkCmdVar =
+      GeneratorTarget->GetCreateRuleVariable(linkLanguage, configName);
+    const char* linkCmd = Makefile->GetDefinition(linkCmdVar);
+    if (linkCmd) {
+      cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+      return;
+    }
+  }
+
+  // If the above failed, then lets try this:
+  switch (GeneratorTarget->GetType()) {
+    case cmState::STATIC_LIBRARY: {
+      // We have archive link commands set. First, delete the existing
+      // archive.
+      {
+        std::string cmakeCommand = LocalGenerator->ConvertToOutputFormat(
+          Makefile->GetRequiredDefinition("CMAKE_COMMAND"),
+          cmLocalGenerator::SHELL);
+        linkCmds.push_back(cmakeCommand + " -E remove $TARGET_FILE");
+      }
+      // TODO: Use ARCHIVE_APPEND for archives over a certain size.
+      {
+        std::string linkCmdVar = "CMAKE_";
+        linkCmdVar += linkLanguage;
+        linkCmdVar += "_ARCHIVE_CREATE";
+        const char* linkCmd = Makefile->GetRequiredDefinition(linkCmdVar);
+        cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+      }
+      {
+        std::string linkCmdVar = "CMAKE_";
+        linkCmdVar += linkLanguage;
+        linkCmdVar += "_ARCHIVE_FINISH";
+        const char* linkCmd = Makefile->GetRequiredDefinition(linkCmdVar);
+        cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+      }
+      return;
+    }
+    case cmState::SHARED_LIBRARY:
+    case cmState::MODULE_LIBRARY:
+    case cmState::EXECUTABLE:
+      break;
+    default:
+      assert(0 && "Unexpected target type");
+  }
+  return;
+}
+
+std::string cmFastbuildTargetGenerator::ComputeDefines(
+  const cmSourceFile* source, const std::string& configName,
+  const std::string& language)
+{
+  std::set<std::string> defines;
+
+  // Add the export symbol definition for shared library objects.
+  if (const char* exportMacro = GeneratorTarget->GetExportMacro()) {
+    LocalGenerator->AppendDefines(defines, exportMacro);
+  }
+
+  // Add preprocessor definitions for this target and configuration.
+  LocalGenerator->AddCompileDefinitions(defines, GeneratorTarget, configName,
+                                        language);
+
+  if (source) {
+    LocalGenerator->AppendDefines(defines,
+                                  source->GetProperty("COMPILE_DEFINITIONS"));
+
+    std::string defPropName = "COMPILE_DEFINITIONS_";
+    defPropName += cmSystemTools::UpperCase(configName);
+    LocalGenerator->AppendDefines(defines, source->GetProperty(defPropName));
+  }
+
+  // Add a definition for the configuration name.
+  // NOTE: CMAKE_TEST_REQUIREMENT The following was added specifically to
+  // facillitate cmake testing. Doesn't feel right to do this...
+  std::string configDefine = "CMAKE_INTDIR=\"";
+  configDefine += configName;
+  configDefine += "\"";
+  LocalGenerator->AppendDefines(defines, configDefine);
+
+  std::string definesString;
+  LocalGenerator->JoinDefines(defines, definesString, language);
+
+  return definesString;
+}
+
+void cmFastbuildTargetGenerator::DetectBaseCompileCommand(
+  std::string& command, const std::string& language)
+{
+  cmLocalGenerator::RuleVariables compileObjectVars;
+  compileObjectVars.CMTarget = GeneratorTarget;
+  compileObjectVars.Language = language.c_str();
+  compileObjectVars.Source =
+    FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+  compileObjectVars.Object =
+    FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+  compileObjectVars.ObjectDir =
+    FASTBUILD_DOLLAR_TAG "TargetOutputDir" FASTBUILD_DOLLAR_TAG;
+  compileObjectVars.ObjectFileDir = "";
+  compileObjectVars.Flags = "";
+  compileObjectVars.Includes = "";
+  const std::string manifests = this->GetManifests();
+  compileObjectVars.Manifests = manifests.c_str();
+  compileObjectVars.Defines = "";
+  compileObjectVars.TargetCompilePDB = FASTBUILD_DOLLAR_TAG
+    "TargetOutCompilePDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
+    "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
+
+  // Rule for compiling object file.
+  std::string compileCmdVar = "CMAKE_";
+  compileCmdVar += language;
+  compileCmdVar += "_COMPILE_OBJECT";
+  std::string compileCmd =
+    LocalGenerator->GetMakefile()->GetRequiredDefinition(compileCmdVar);
+  std::vector<std::string> compileCmds;
+  cmSystemTools::ExpandListArgument(compileCmd, compileCmds);
+
+  for (std::vector<std::string>::iterator i = compileCmds.begin();
+       i != compileCmds.end(); ++i) {
+    std::string& compileCmdStr = *i;
+    ((cmLocalFastbuildGenerator*)LocalGenerator)
+      ->ExpandRuleVariables(compileCmdStr, compileObjectVars);
+  }
+
+  command = BuildCommandLine(compileCmds);
+}
+
+void cmFastbuildTargetGenerator::DetectTargetObjectDependencies(
+  const std::string& configName, std::vector<std::string>& dependencies)
+{
+  // Iterate over all source files and look for
+  // object file dependencies
+
+  std::set<std::string> objectLibs;
+
+  std::vector<cmSourceFile*> sourceFiles;
+  GeneratorTarget->GetSourceFiles(sourceFiles, configName);
+  for (std::vector<cmSourceFile*>::const_iterator i = sourceFiles.begin();
+       i != sourceFiles.end(); ++i) {
+    const std::string& objectLib = (*i)->GetObjectLibrary();
+    if (!objectLib.empty()) {
+      // Find the target this actually is (might be an alias)
+      const cmTarget* objectTarget = GlobalGenerator->FindTarget(objectLib);
+      if (objectTarget) {
+        objectLibs.insert(objectTarget->GetName() + "-" + configName +
+                          "-products");
+      }
+    }
+  }
+
+  std::copy(objectLibs.begin(), objectLibs.end(),
+            std::back_inserter(dependencies));
+
+  // Now add the external obj files that also need to be linked in
+  std::vector<const cmSourceFile*> objFiles;
+  GeneratorTarget->GetExternalObjects(objFiles, configName);
+  for (std::vector<const cmSourceFile*>::const_iterator i = objFiles.begin();
+       i != objFiles.end(); ++i) {
+    const cmSourceFile* sourceFile = *i;
+    if (sourceFile->GetObjectLibrary().empty()) {
+      dependencies.push_back(sourceFile->GetFullPath());
+    }
+  }
+}
+
+void cmFastbuildTargetGenerator::DetectTargetLinkDependencies(
+  const std::string& configName, std::vector<std::string>& dependencies)
+{
+  // Static libraries never depend on other targets for linking.
+  if (GeneratorTarget->GetType() == cmState::STATIC_LIBRARY ||
+      GeneratorTarget->GetType() == cmState::OBJECT_LIBRARY) {
+    return;
+  }
+
+  cmComputeLinkInformation* cli =
+    GeneratorTarget->GetLinkInformation(configName);
+  if (!cli) {
+    return;
+  }
+
+  const std::vector<std::string>& deps = cli->GetDepends();
+  std::copy(deps.begin(), deps.end(), std::back_inserter(dependencies));
+}
+
+std::string cmFastbuildTargetGenerator::DetectTargetCompileOutputDir(
+
+  std::string configName) const
+{
+  std::string result =
+    LocalGenerator->GetTargetDirectory(GeneratorTarget) + "/";
+  if (!configName.empty()) {
+    result = result + configName + "/";
+  }
+  cmSystemTools::ConvertToOutputSlashes(result);
+  return result;
+}
+
+void cmFastbuildTargetGenerator::UnescapeFastbuildVariables(
+  std::string& string)
+{
+  // Unescape the Fastbuild configName symbol with $
+  cmSystemTools::ReplaceString(string, "^", "^^");
+  cmSystemTools::ReplaceString(string, "$$", "^$");
+  cmSystemTools::ReplaceString(string, FASTBUILD_DOLLAR_TAG, "$");
+  // cmSystemTools::ReplaceString(string, "$$ConfigName$$", "$ConfigName$");
+  // cmSystemTools::ReplaceString(string, "^$ConfigName^$", "$ConfigName$");
+}
+
+bool cmFastbuildTargetGenerator::isConfigDependant(
+  const cmCustomCommandGenerator* ccg)
+{
+  typedef std::vector<std::string> StringVector;
+  StringVector outputs = ccg->GetOutputs();
+  StringVector byproducts = ccg->GetByproducts();
+
+  std::for_each(outputs.begin(), outputs.end(), &UnescapeFastbuildVariables);
+  std::for_each(byproducts.begin(), byproducts.end(),
+                &UnescapeFastbuildVariables);
+
+  // Make sure that the outputs don't depend on the config name
+  for (StringVector::const_iterator iter = outputs.begin();
+       iter != outputs.end(); ++iter) {
+    const std::string& str = *iter;
+    if (str.find("$ConfigName$") != std::string::npos) {
+      return true;
+    }
+  }
+  for (StringVector::const_iterator iter = byproducts.begin();
+       iter != byproducts.end(); ++iter) {
+    const std::string& str = *iter;
+    if (str.find("$ConfigName$") != std::string::npos) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+std::string cmFastbuildTargetGenerator::BuildCommandLine(
+  const std::vector<std::string>& cmdLines)
+{
+#ifdef _WIN32
+  const char* cmdExe = "cmd.exe";
+  std::string cmdExeAbsolutePath = cmSystemTools::FindProgram(cmdExe);
+#endif
+
+  // If we have no commands but we need to build a command anyway, use ":".
+  // This happens when building a POST_BUILD value for link targets that
+  // don't use POST_BUILD.
+  if (cmdLines.empty()) {
+#ifdef _WIN32
+    return cmdExeAbsolutePath + " /C \"cd .\"";
+#else
+    return ":";
+#endif
+  }
+
+  std::ostringstream cmd;
+  for (std::vector<std::string>::const_iterator li = cmdLines.begin();
+       li != cmdLines.end(); ++li)
+#ifdef _WIN32
+  {
+    if (li != cmdLines.begin()) {
+      cmd << " && ";
+    } else if (cmdLines.size() > 1) {
+      cmd << cmdExeAbsolutePath << " /C \"";
+    }
+    cmd << *li;
+  }
+  if (cmdLines.size() > 1) {
+    cmd << "\"";
+  }
+#else
+  {
+    if (li != cmdLines.begin()) {
+      cmd << " && ";
+    }
+    cmd << *li;
+  }
+#endif
+  std::string cmdOut = cmd.str();
+  UnescapeFastbuildVariables(cmdOut);
+
+  return cmdOut;
+}
+
+void cmFastbuildTargetGenerator::SplitExecutableAndFlags(
+  const std::string& command, std::string& executable, std::string& options)
+{
+  // Remove the command from the front
+  std::vector<std::string> args =
+    cmSystemTools::ParseArguments(command.c_str());
+
+  // Join the args together and remove 0 from the front
+  std::stringstream argSet;
+  std::copy(args.begin() + 1, args.end(),
+            std::ostream_iterator<std::string>(argSet, " "));
+
+  executable = args[0];
+  options = argSet.str();
+}
+
+void cmFastbuildTargetGenerator::EnsureDirectoryExists(
+  const std::string& path, const char* homeOutputDirectory)
+{
+  if (cmSystemTools::FileIsFullPath(path.c_str())) {
+    cmSystemTools::MakeDirectory(path.c_str());
+  } else {
+    const std::string fullPath = std::string(homeOutputDirectory) + "/" + path;
+    cmSystemTools::MakeDirectory(fullPath.c_str());
+  }
+}
+
+std::string cmFastbuildTargetGenerator::GetLastFolderName(
+  const std::string& string)
+{
+  return string.substr(string.rfind('/') + 1);
+}
+
+void cmFastbuildTargetGenerator::ResolveFastbuildVariables(
+  std::string& string, const std::string& configName)
+{ // Replace Fastbuild configName with the config name
+  cmSystemTools::ReplaceString(string, "$ConfigName$", configName);
+}
+
+void cmFastbuildTargetGenerator::Generate()
+{
+  // Detection of the link command as follows:
+  std::string linkCommand = "Library";
+  switch (GeneratorTarget->GetType()) {
+    case cmState::INTERFACE_LIBRARY:
+      // We don't write out interface libraries.
+      return;
+    case cmState::EXECUTABLE: {
+      linkCommand = "Executable";
+      break;
+    }
+    case cmState::SHARED_LIBRARY: {
+      linkCommand = "DLL";
+      break;
+    }
+    case cmState::STATIC_LIBRARY:
+    case cmState::MODULE_LIBRARY:
+    case cmState::OBJECT_LIBRARY: {
+      // No changes required
+      break;
+    }
+    case cmState::UTILITY:
+    case cmState::GLOBAL_TARGET: {
+      // No link command used
+      linkCommand = "NoLinkCommand";
+      break;
+    }
+    case cmState::UNKNOWN_LIBRARY: {
+      // Ignoring this target generation...
+      return;
+    }
+  }
+
+  const std::string& targetName = GeneratorTarget->GetName();
+
+  m_fileContext.WriteComment("Target definition: " + targetName);
+  m_fileContext.WritePushScope();
+
+  std::vector<std::string> dependencies;
+  DetectTargetCompileDependencies(GlobalGenerator, dependencies);
+
+  // Iterate over each configuration
+  // This time to define linker settings for each config
+  std::vector<std::string> configs;
+  Makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator configIter = configs.begin();
+       configIter != configs.end(); ++configIter) {
+    const std::string& configName = *configIter;
+
+    m_fileContext.WriteVariable("BaseConfig_" + configName, "");
+    m_fileContext.WritePushScopeStruct();
+
+    m_fileContext.WriteCommand("Using", ".ConfigBase");
+
+    m_fileContext.WriteVariable("ConfigName",
+                                cmGlobalFastbuildGenerator::Quote(configName));
+
+    m_fileContext.WriteBlankLine();
+    m_fileContext.WriteComment("General output details:");
+    // Write out the output paths for the outcome of this target
+    {
+      FastbuildTargetNames targetNames;
+      DetectOutput(targetNames, configName);
+
+      m_fileContext.WriteVariable(
+        "TargetNameOut",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetNameOut));
+      m_fileContext.WriteVariable(
+        "TargetNameImport",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetNameImport));
+      m_fileContext.WriteVariable(
+        "TargetNamePDB",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetNamePDB));
+      m_fileContext.WriteVariable(
+        "TargetNameSO",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetNameSO));
+      m_fileContext.WriteVariable(
+        "TargetNameReal",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetNameReal));
+
+      // TODO: Remove this if these variables aren't used...
+      // They've been added for testing
+      m_fileContext.WriteVariable(
+        "TargetOutput",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetOutput));
+      m_fileContext.WriteVariable(
+        "TargetOutputImplib",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetOutputImplib));
+      m_fileContext.WriteVariable(
+        "TargetOutputReal",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetOutputReal));
+      m_fileContext.WriteVariable(
+        "TargetOutDir",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetOutputDir));
+      m_fileContext.WriteVariable("TargetOutCompilePDBDir",
+                                  cmGlobalFastbuildGenerator::Quote(
+                                    targetNames.targetOutputCompilePDBDir));
+      m_fileContext.WriteVariable(
+        "TargetOutPDBDir",
+        cmGlobalFastbuildGenerator::Quote(targetNames.targetOutputPDBDir));
+
+      // Compile directory always needs to exist
+      EnsureDirectoryExists(targetNames.targetOutputCompilePDBDir,
+                            Makefile->GetHomeOutputDirectory());
+
+      if (GeneratorTarget->GetType() != cmState::OBJECT_LIBRARY) {
+        // on Windows the output dir is already needed at compile time
+        // ensure the directory exists (OutDir test)
+        EnsureDirectoryExists(targetNames.targetOutputDir,
+                              Makefile->GetHomeOutputDirectory());
+        EnsureDirectoryExists(targetNames.targetOutputPDBDir,
+                              Makefile->GetHomeOutputDirectory());
+      }
+    }
+
+    // Write the dependency list in here too
+    // So all dependant libraries are built before this one is
+    // This is incase this library depends on code generated from previous
+    // ones
+    {
+      m_fileContext.WriteArray("PreBuildDependencies",
+                               cmGlobalFastbuildGenerator::Wrap(
+                                 dependencies, "'", "-" + configName + "'"));
+    }
+
+    m_fileContext.WritePopScope();
+  }
+
+  // Output the prebuild/Prelink commands
+  WriteCustomBuildSteps(GeneratorTarget->GetPreBuildCommands(), "PreBuild",
+                        dependencies);
+  WriteCustomBuildSteps(GeneratorTarget->GetPreLinkCommands(), "PreLink",
+                        dependencies);
+
+  // Iterate over each configuration
+  // This time to define prebuild and post build targets for each config
+  for (std::vector<std::string>::const_iterator configIter = configs.begin();
+       configIter != configs.end(); ++configIter) {
+    const std::string& configName = *configIter;
+
+    m_fileContext.WriteVariable("BaseCompilationConfig_" + configName, "");
+    m_fileContext.WritePushScopeStruct();
+
+    m_fileContext.WriteCommand("Using", ".BaseConfig_" + configName);
+
+    // Add to the list of prebuild deps
+    // The prelink and prebuild commands
+    {
+      std::vector<std::string> preBuildSteps;
+      if (!GeneratorTarget->GetPreBuildCommands().empty()) {
+        preBuildSteps.push_back("PreBuild");
+      }
+      if (!GeneratorTarget->GetPreLinkCommands().empty()) {
+        preBuildSteps.push_back("PreLink");
+      }
+
+      if (!preBuildSteps.empty()) {
+        m_fileContext.WriteArray(
+          "PreBuildDependencies",
+          cmGlobalFastbuildGenerator::Wrap(
+            preBuildSteps, "'" + targetName + "-", "-" + configName + "'"),
+          "+");
+      }
+    }
+
+    m_fileContext.WritePopScope();
+  }
+
+  // Write the custom build rules
+  bool hasCustomBuildRules = WriteCustomBuildRules();
+
+  // Figure out the list of languages in use by this target
+  std::vector<std::string> linkableDeps;
+  std::vector<std::string> orderDeps;
+  std::set<std::string> languages;
+  cmGlobalFastbuildGenerator::Detail::Detection::DetectLanguages(
+    languages, GeneratorTarget);
+
+  // Write the object list definitions for each language
+  // stored in this target
+  for (std::set<std::string>::iterator langIter = languages.begin();
+       langIter != languages.end(); ++langIter) {
+    const std::string& objectGroupLanguage = *langIter;
+    std::string ruleObjectGroupName = "ObjectGroup_" + objectGroupLanguage;
+    linkableDeps.push_back(ruleObjectGroupName);
+
+    m_fileContext.WriteVariable(ruleObjectGroupName, "");
+    m_fileContext.WritePushScopeStruct();
+
+    // Iterating over all configurations
+    for (std::vector<std::string>::const_iterator configIter = configs.begin();
+         configIter != configs.end(); ++configIter) {
+      const std::string& configName = *configIter;
+      m_fileContext.WriteVariable("ObjectConfig_" + configName, "");
+      m_fileContext.WritePushScopeStruct();
+
+      m_fileContext.WriteCommand("Using",
+                                 ".BaseCompilationConfig_" + configName);
+      m_fileContext.WriteCommand("Using", ".CustomCommands_" + configName);
+
+      m_fileContext.WriteBlankLine();
+      m_fileContext.WriteComment("Compiler options:");
+
+      // Compiler options
+      std::string baseCompileFlags;
+      {
+        // Remove the command from the front and leave the flags behind
+        std::string compileCmd;
+        DetectBaseCompileCommand(compileCmd, objectGroupLanguage);
+
+        // No need to double unescape the variables
+        // Detection::UnescapeFastbuildVariables(compileCmd);
+
+        std::string executable;
+        SplitExecutableAndFlags(compileCmd, executable, baseCompileFlags);
+
+        m_fileContext.WriteVariable(
+          "CompilerCmdBaseFlags",
+          cmGlobalFastbuildGenerator::Quote(baseCompileFlags));
+
+        std::string compilerName = ".Compiler_" + objectGroupLanguage;
+        m_fileContext.WriteVariable("Compiler", compilerName);
+      }
+
+      std::map<std::string,
+               cmGlobalFastbuildGenerator::Detail::Generation::CompileCommand>
+        commandPermutations;
+
+      // Source files
+      m_fileContext.WriteBlankLine();
+      m_fileContext.WriteComment("Source files:");
+      {
+        // get a list of source files
+        std::vector<cmSourceFile const*> objectSources;
+        GeneratorTarget->GetObjectSources(objectSources, configName);
+
+        std::vector<cmSourceFile const*> filteredObjectSources;
+        cmGlobalFastbuildGenerator::Detail::Detection::FilterSourceFiles(
+          filteredObjectSources, objectSources, objectGroupLanguage);
+
+        // Figure out the compilation commands for all
+        // the translation units in the compilation.
+        // Detect if one of them is a PreCompiledHeader
+        // and extract it to be used in a precompiled header
+        // generation step.
+        for (std::vector<cmSourceFile const*>::iterator sourceIter =
+               filteredObjectSources.begin();
+             sourceIter != filteredObjectSources.end(); ++sourceIter) {
+          cmSourceFile const* srcFile = *sourceIter;
+          std::string sourceFile = srcFile->GetFullPath();
+
+          // Detect flags and defines
+          std::string compilerFlags;
+          cmGlobalFastbuildGenerator::Detail::Detection::DetectCompilerFlags(
+            compilerFlags, LocalGenerator, GeneratorTarget, srcFile,
+            objectGroupLanguage, configName);
+          std::string compileDefines =
+            ComputeDefines(srcFile, configName, objectGroupLanguage);
+
+          UnescapeFastbuildVariables(compilerFlags);
+          UnescapeFastbuildVariables(compileDefines);
+
+          std::string configKey = compilerFlags + "{|}" + compileDefines;
+          cmGlobalFastbuildGenerator::Detail::Generation::CompileCommand&
+            command = commandPermutations[configKey];
+          command.sourceFiles[srcFile->GetLocation().GetDirectory()].push_back(
+            sourceFile);
+          command.flags = compilerFlags;
+          command.defines = compileDefines;
+        }
+      }
+
+      // Iterate over all subObjectGroups
+      std::string objectGroupRuleName =
+        targetName + "-" + ruleObjectGroupName + "-" + configName;
+      std::vector<std::string> configObjectGroups;
+      int groupNameCount = 1;
+      for (std::map<std::string, cmGlobalFastbuildGenerator::Detail::
+                                   Generation::CompileCommand>::iterator
+             groupIter = commandPermutations.begin();
+           groupIter != commandPermutations.end(); ++groupIter) {
+        m_fileContext.WritePushScope();
+
+        const cmGlobalFastbuildGenerator::Detail::Generation::CompileCommand&
+          command = groupIter->second;
+
+        m_fileContext.WriteVariable(
+          "CompileDefineFlags",
+          cmGlobalFastbuildGenerator::Quote(command.defines));
+        m_fileContext.WriteVariable(
+          "CompileFlags", cmGlobalFastbuildGenerator::Quote(command.flags));
+        m_fileContext.WriteVariable(
+          "CompilerOptions",
+          cmGlobalFastbuildGenerator::Quote(
+            "$CompileFlags$ $CompileDefineFlags$ $CompilerCmdBaseFlags$"));
+
+        if (objectGroupLanguage == "RC") {
+          m_fileContext.WriteVariable(
+            "CompilerOutputExtension",
+            cmGlobalFastbuildGenerator::Quote(".res"));
+        } else {
+          m_fileContext.WriteVariable("CompilerOutputExtension",
+                                      cmGlobalFastbuildGenerator::Quote(
+                                        "." + objectGroupLanguage + ".obj"));
+        }
+
+        std::map<std::string, std::vector<std::string> >::const_iterator
+          objectListIt;
+        for (objectListIt = command.sourceFiles.begin();
+             objectListIt != command.sourceFiles.end(); ++objectListIt) {
+          const std::string folderName(GetLastFolderName(objectListIt->first));
+          std::stringstream ruleName;
+          ruleName << objectGroupRuleName << "-" << folderName << "-"
+                   << (groupNameCount++);
+
+          m_fileContext.WriteCommand(
+            "ObjectList", cmGlobalFastbuildGenerator::Quote(ruleName.str()));
+          m_fileContext.WritePushScope();
+
+          m_fileContext.WriteArray(
+            "CompilerInputFiles",
+            cmGlobalFastbuildGenerator::Wrap(objectListIt->second, "'", "'"));
+
+          configObjectGroups.push_back(ruleName.str());
+
+          std::string targetCompileOutDirectory =
+            DetectTargetCompileOutputDir(configName) + "/" + folderName;
+          cmSystemTools::ConvertToOutputSlashes(targetCompileOutDirectory);
+          m_fileContext.WriteVariable(
+            "CompilerOutputPath",
+            cmGlobalFastbuildGenerator::Quote(targetCompileOutDirectory));
+
+          // Unity source files:
+          m_fileContext.WriteVariable("UnityInputFiles",
+                                      ".CompilerInputFiles");
+
+          /*
+          if
+          (cmGlobalFastbuildGenerator::Detail::Detection::DetectPrecompiledHeader(command.flags
+          + " " +
+              baseCompileFlags + " " + command.defines,
+              preCompiledHeaderInput,
+              preCompiledHeaderOutput,
+              preCompiledHeaderOptions)
+          */
+          m_fileContext.WritePopScope();
+        }
+
+        m_fileContext.WritePopScope();
+      }
+
+      if (!configObjectGroups.empty()) {
+        // Write an alias for this object group to group them all together
+        m_fileContext.WriteCommand(
+          "Alias", cmGlobalFastbuildGenerator::Quote(objectGroupRuleName));
+        m_fileContext.WritePushScope();
+        m_fileContext.WriteArray("Targets", cmGlobalFastbuildGenerator::Wrap(
+                                              configObjectGroups, "'", "'"));
+        m_fileContext.WritePopScope();
+      }
+
+      m_fileContext.WritePopScope();
+    }
+    m_fileContext.WritePopScope();
+  }
+
+  // Object libraries do not have linker stages
+  // nor utilities
+  const bool hasLinkerStage =
+    GeneratorTarget->GetType() != cmState::OBJECT_LIBRARY &&
+    GeneratorTarget->GetType() != cmState::UTILITY &&
+    GeneratorTarget->GetType() != cmState::GLOBAL_TARGET;
+
+  // Iterate over each configuration
+  // This time to define linker settings for each config
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    const std::string& configName = *iter;
+
+    std::string linkRuleName = targetName + "-link-" + configName;
+
+    if (hasLinkerStage) {
+
+      m_fileContext.WriteVariable("LinkerConfig_" + configName, "");
+      m_fileContext.WritePushScopeStruct();
+
+      m_fileContext.WriteCommand("Using", ".BaseConfig_" + configName);
+
+      m_fileContext.WriteBlankLine();
+      m_fileContext.WriteComment("Linker options:");
+      // Linker options
+      {
+        std::string linkLibs;
+        std::string targetFlags;
+        std::string linkFlags;
+        std::string frameworkPath;
+        std::string dummyLinkPath;
+
+        LocalGenerator->GetTargetFlags(configName, linkLibs, targetFlags,
+                                       linkFlags, frameworkPath, dummyLinkPath,
+                                       GeneratorTarget, false);
+
+        std::string linkPath;
+        DetectLinkerLibPaths(linkPath, configName);
+
+        UnescapeFastbuildVariables(linkLibs);
+        UnescapeFastbuildVariables(targetFlags);
+        UnescapeFastbuildVariables(linkFlags);
+        UnescapeFastbuildVariables(frameworkPath);
+        UnescapeFastbuildVariables(linkPath);
+
+        linkPath = frameworkPath + linkPath;
+
+        if (GeneratorTarget->IsExecutableWithExports()) {
+          const char* defFileFlag =
+            LocalGenerator->GetMakefile()->GetDefinition(
+              "CMAKE_LINK_DEF_FILE_FLAG");
+          const cmSourceFile* defFile =
+            GeneratorTarget->GetModuleDefinitionFile(configName);
+          if (defFile && !defFile->GetFullPath().empty()) {
+            linkFlags += defFileFlag + defFile->GetFullPath();
+          }
+        }
+
+        m_fileContext.WriteVariable("LinkPath", "'" + linkPath + "'");
+        m_fileContext.WriteVariable("LinkLibs", "'" + linkLibs + "'");
+        m_fileContext.WriteVariable("LinkFlags", "'" + linkFlags + "'");
+        m_fileContext.WriteVariable("TargetFlags", "'" + targetFlags + "'");
+
+        // Remove the command from the front and leave the flags behind
+        std::string linkCmd;
+        if (!DetectBaseLinkerCommand(linkCmd, configName)) {
+          return;
+        }
+        // No need to do this, because the function above has already escaped
+        // things appropriately
+        // UnescapeFastbuildVariables(linkCmd);
+
+        std::string executable;
+        std::string flags;
+        SplitExecutableAndFlags(linkCmd, executable, flags);
+
+        std::string language = GeneratorTarget->GetLinkerLanguage(configName);
+        std::string linkerType =
+          LocalGenerator->GetMakefile()->GetSafeDefinition(
+            "CMAKE_" + language + "_COMPILER_ID");
+
+        m_fileContext.WriteVariable(
+          "Linker", cmGlobalFastbuildGenerator::Quote(executable));
+        m_fileContext.WriteVariable(
+          "LinkerType", cmGlobalFastbuildGenerator::Quote(linkerType));
+        m_fileContext.WriteVariable("BaseLinkerOptions",
+                                    cmGlobalFastbuildGenerator::Quote(flags));
+
+        m_fileContext.WriteVariable("LinkerOutput", "'$TargetOutput$'");
+        m_fileContext.WriteVariable("LinkerOptions",
+                                    "'$BaseLinkerOptions$ $LinkLibs$'");
+
+        m_fileContext.WriteArray(
+          "Libraries",
+          cmGlobalFastbuildGenerator::Wrap(
+            linkableDeps, "'" + targetName + "-", "-" + configName + "'"));
+
+        // Now detect the extra dependencies for linking
+        {
+          std::vector<std::string> extraDependencies;
+          DetectTargetObjectDependencies(configName, extraDependencies);
+          DetectTargetLinkDependencies(configName, extraDependencies);
+
+          std::for_each(extraDependencies.begin(), extraDependencies.end(),
+                        UnescapeFastbuildVariables);
+
+          m_fileContext.WriteArray(
+            "Libraries",
+            cmGlobalFastbuildGenerator::Wrap(extraDependencies, "'", "'"),
+            "+");
+        }
+
+        m_fileContext.WriteCommand(
+          linkCommand, cmGlobalFastbuildGenerator::Quote(linkRuleName));
+        m_fileContext.WritePushScope();
+        if (linkCommand == "Library") {
+          m_fileContext.WriteComment(
+            "Convert the linker options to work with libraries");
+
+          // Push dummy definitions for compilation variables
+          // These variables are required by the Library command
+          m_fileContext.WriteVariable("Compiler", ".Compiler_dummy");
+          m_fileContext.WriteVariable(
+            "CompilerOptions",
+            "'-c $FB_INPUT_1_PLACEHOLDER$ $FB_INPUT_2_PLACEHOLDER$'");
+          m_fileContext.WriteVariable("CompilerOutputPath", "'/dummy/'");
+
+          // These variables are required by the Library command as well
+          // we just need to transfer the values in the linker variables
+          // to these locations
+          m_fileContext.WriteVariable("Librarian", "'$Linker$'");
+          m_fileContext.WriteVariable("LibrarianOptions", "'$LinkerOptions$'");
+          m_fileContext.WriteVariable("LibrarianOutput", "'$LinkerOutput$'");
+
+          m_fileContext.WriteVariable("LibrarianAdditionalInputs",
+                                      ".Libraries");
+        }
+        m_fileContext.WritePopScope();
+      }
+      m_fileContext.WritePopScope();
+    }
+  }
+
+  if (!GeneratorTarget->GetPreBuildCommands().empty()) {
+    orderDeps.push_back("PreBuild");
+  }
+  if (!GeneratorTarget->GetPreLinkCommands().empty()) {
+    orderDeps.push_back("PreLink");
+  }
+  if (hasCustomBuildRules) {
+    orderDeps.push_back("CustomCommands");
+  }
+  if (hasLinkerStage) {
+    linkableDeps.push_back("link");
+    orderDeps.push_back("link");
+  }
+
+  // Output the postbuild commands
+  WriteCustomBuildSteps(
+    GeneratorTarget->GetPostBuildCommands(), "PostBuild",
+    cmGlobalFastbuildGenerator::Wrap(orderDeps, targetName + "-", ""));
+
+  // Always add the pre/post build steps as
+  // part of the alias.
+  // This way, if there are ONLY build steps, then
+  // things should still work too.
+  if (!GeneratorTarget->GetPostBuildCommands().empty()) {
+    orderDeps.push_back("PostBuild");
+  }
+
+  // Output a list of aliases
+  this->WriteTargetAliases(linkableDeps, orderDeps);
+
+  m_fileContext.WritePopScope();
+}

--- a/Source/cmFastbuildTargetGenerator.cxx
+++ b/Source/cmFastbuildTargetGenerator.cxx
@@ -137,8 +137,8 @@ void cmFastbuildTargetGenerator::WriteCustomBuildSteps(
   }
 }
 
-void cmFastbuildTargetGenerator::AddIncludeFlags(std::string& flags,
-                                                 const std::string& lang)
+void cmFastbuildTargetGenerator::AddIncludeFlags(std::string& /* flags */,
+                                                 const std::string& /* lang */)
 {
 }
 
@@ -390,7 +390,7 @@ void cmFastbuildTargetGenerator::WriteCustomCommand(
       "ExecArguments",
       cmGlobalFastbuildGenerator::Quote("/C " + scriptFileName));
 #else
-    context.fc.WriteVariable("ExecExecutable", Quote(scriptFileName));
+      m_fileContext.WriteVariable("ExecExecutable", cmGlobalFastbuildGenerator::Quote(scriptFileName));
 #endif
     if (!workingDirectory.empty()) {
       m_fileContext.WriteVariable(

--- a/Source/cmFastbuildTargetGenerator.h
+++ b/Source/cmFastbuildTargetGenerator.h
@@ -1,0 +1,100 @@
+#ifndef CMFASTBUILDNORMALTARGETGENERATOR_H
+#define CMFASTBUILDNORMALTARGETGENERATOR_H
+
+#include "cmCommonTargetGenerator.h"
+#include "cmGlobalFastbuildGenerator.h"
+
+class cmFastbuildTargetGenerator : public cmCommonTargetGenerator
+{
+public:
+  cmFastbuildTargetGenerator(cmGeneratorTarget* gt);
+
+  virtual void Generate();
+
+private:
+  void DetectTargetCompileDependencies(cmGlobalCommonGenerator* gg,
+                                       std::vector<std::string>& dependencies);
+
+  void WriteTargetAliases(const std::vector<std::string>& linkableDeps,
+                          const std::vector<std::string>& orderDeps);
+
+  void WriteCustomBuildSteps(const std::vector<cmCustomCommand>& commands,
+                             const std::string& buildStep,
+                             const std::vector<std::string>& orderDeps);
+
+  virtual void AddIncludeFlags(std::string& flags, std::string const& lang);
+
+  bool WriteCustomBuildRules();
+
+  void WriteCustomCommand(const cmCustomCommand* cc,
+                          const std::string& configName,
+                          std::string& targetName,
+                          const std::string& hostTargetName);
+
+  struct FastbuildTargetNames
+  {
+    std::string targetNameOut;
+    std::string targetNameReal;
+    std::string targetNameImport;
+    std::string targetNamePDB;
+    std::string targetNameSO;
+
+    std::string targetOutput;
+    std::string targetOutputReal;
+    std::string targetOutputImplib;
+    std::string targetOutputDir;
+    std::string targetOutputPDBDir;
+    std::string targetOutputCompilePDBDir;
+  };
+  void DetectOutput(FastbuildTargetNames& targetNamesOut,
+                    const std::string& configName);
+
+  void DetectLinkerLibPaths(std::string& linkerLibPath,
+                            const std::string& configName);
+  bool DetectBaseLinkerCommand(std::string& command,
+                               const std::string& configName);
+
+  void ComputeLinkCmds(std::vector<std::string>& linkCmds,
+                       std::string configName);
+
+  std::string ComputeDefines(const cmSourceFile* source,
+                             const std::string& configName,
+                             const std::string& language);
+
+  void DetectBaseCompileCommand(std::string& command,
+                                const std::string& language);
+
+  void DetectTargetObjectDependencies(const std::string& configName,
+                                      std::vector<std::string>& dependencies);
+
+  void DetectTargetLinkDependencies(const std::string& configName,
+                                    std::vector<std::string>& dependencies);
+
+  std::string DetectTargetCompileOutputDir(std::string configName) const;
+
+  cmGlobalFastbuildGenerator::Detail::FileContext& m_fileContext;
+
+  static void UnescapeFastbuildVariables(std::string& string);
+
+  static bool isConfigDependant(const cmCustomCommandGenerator* ccg);
+
+  static std::string BuildCommandLine(
+    const std::vector<std::string>& cmdLines);
+
+  static void SplitExecutableAndFlags(const std::string& command,
+                                      std::string& executable,
+                                      std::string& options);
+
+  static void EnsureDirectoryExists(const std::string& path,
+                                    const char* homeOutputDirectory);
+
+  static std::string GetLastFolderName(const std::string& string);
+
+  static void ResolveFastbuildVariables(std::string& string,
+                                        const std::string& configName);
+
+  static cmGlobalFastbuildGenerator::Detail::Generation::CustomCommandAliasMap
+    s_customCommandAliases;
+};
+
+#endif // CMFASTBUILDNORMALTARGETGENERATOR_H

--- a/Source/cmGeneratorExpressionNode.cxx
+++ b/Source/cmGeneratorExpressionNode.cxx
@@ -826,7 +826,8 @@ static const struct CompileLanguageNode : public cmGeneratorExpressionNode
     } else {
       if (genName.find("Makefiles") == std::string::npos &&
           genName.find("Ninja") == std::string::npos &&
-          genName.find("Watcom WMake") == std::string::npos) {
+          genName.find("Watcom WMake") == std::string::npos &&
+          genName.find("Fastbuild") == std::string::npos) {
         reportError(
           context, content->GetOriginalExpression(),
           "$<COMPILE_LANGUAGE:...> not supported for this generator.");

--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -1,0 +1,2561 @@
+
+/*============================================================================
+  CMake - Cross Platform Makefile Generator
+  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+
+  Distributed under the OSI-approved BSD License (the "License");
+  see accompanying file Copyright.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the License for more information.
+============================================================================*/
+/*============================================================================
+  Development progress:
+
+  Tasks/Issues:
+   - Execute unit tests against the generator somehow
+   - Fix target aliases being repeated in the output
+   - Fix cmake build using fastbuild (currently appears configuration
+incorrect)
+   - Running some of the Cmake generation, the pdb files can't be deleted
+(shows up errors)
+   - Depends upon visual studio generator code to sort dependencies
+   - When generating CMAKE from scratch, it sometimes errors with fortran
+complaints and fails generation?
+         a re-run will succeed.
+   - Linker for msvc uses the cmake command to callback. Don't think this is an
+issue since
+         I think compilation is the part that gets distributed anyway.
+         But it might mean that the cache has trouble calculating deps for
+obj->lib/exe.
+         Not sure if Fastbuild supports that anyway yet
+   - Need to sort custom build commands by their outputs
+
+  Fastbuild bugs:
+   - Defining prebuild dependencies that don't exist, causes the error output
+when that
+         target is actually defined. Rather than originally complaining that
+the target
+         doesn't exist where the reference is attempted.
+   - Parsing strings with double $$ doesn't generate a nice error
+   - Undocumented that you can escape a $ with ^$
+   - ExecInputs is invalid empty
+   - Would be great if you could define dummy targets (maybe blank aliases?)
+   - Exec nodes need to not worry about dummy output files not being created
+   - Would be nice if nodes didn't need to be completely in order. But then
+cycles would be possible
+
+  Limitations:
+   - Only tested/working with MSVC
+
+  Notes:
+   - Understanding Custom Build Steps and Build Events
+     https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
+         very useful documentation detailing the order of execution
+         of standard MSVC events. This is useful to determine correct
+         behaviour of fastbuild generator (view a project generated to MSVC,
+         then apply the same rules/assumptions back into fastbuild).
+         i.e. Custom rules are always executed first.
+
+  Current list of unit tests failing:
+
+        89% tests passed, 41 tests failed out of 368
+        Total Test time (real) = 8386.39 sec
+
+        The following tests FAILED:
+        58 - SourceGroups (Failed)
+        59 - Preprocess (Failed)
+        60 - ExportImport (Failed)
+        68 - StagingPrefix (Failed)
+        70 - ConfigSources (Failed)
+        78 - Module.ExternalData (Timeout)
+        79 - Module.GenerateExportHeader (Failed)
+        100 - SubProject (Failed)
+        101 - SubProject-Stage2 (Failed)
+        107 - GeneratorExpression (Failed)
+        108 - CustomCommand (Timeout)
+        109 - CustomCommandByproducts (Timeout)
+        112 - OutOfSource (Failed)
+        113 - BuildDepends (Timeout)
+        114 - SimpleInstall (Failed)
+        115 - SimpleInstall-Stage2 (Failed)
+        127 - complex (Failed)
+        128 - complexOneConfig (Failed)
+        131 - ExternalProject (Failed)
+        132 - ExternalProjectLocal (Failed)
+        133 - ExternalProjectUpdateSetup (Failed)
+        134 - ExternalProjectUpdate (Failed)
+        151 - Plugin (Failed)
+        154 - SubDir (Failed)
+        156 - PDBDirectoryAndName (Failed)
+        157 - PrecompiledHeader (Failed)
+        158 - ModuleDefinition (Failed)
+        182 - CTestConfig.Script.Debug (Failed)
+        183 - CTestConfig.Dashboard.Debug (Failed)
+        184 - CTestConfig.Script.MinSizeRel (Failed)
+        185 - CTestConfig.Dashboard.MinSizeRel (Failed)
+        186 - CTestConfig.Script.Release (Failed)
+        187 - CTestConfig.Dashboard.Release (Failed)
+        188 - CTestConfig.Script.RelWithDebInfo (Failed)
+        189 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
+        195 - CMakeCommands.target_compile_options (Failed)
+        221 - Java (Failed)
+        223 - IncludeDirectories (Failed)
+        237 - CMakeOnly.CheckStructHasMember (Failed)
+        274 - RunCMake.Configure (Failed)
+        330 - RunCMake.File_Generate (Failed)
+============================================================================*/
+#include "cmGlobalFastbuildGenerator.h"
+
+#include "cmComputeLinkInformation.h"
+#include "cmCustomCommandGenerator.h"
+#include "cmGeneratedFileStream.h"
+#include "cmGeneratorTarget.h"
+#include "cmGlobalGeneratorFactory.h"
+#include "cmGlobalVisualStudioGenerator.h"
+#include "cmLocalFastbuildGenerator.h"
+#include "cmLocalGenerator.h"
+#include "cmMakefile.h"
+#include "cmSourceFile.h"
+#include "cmTarget.h"
+#include <assert.h>
+#include <cmsys/Encoding.hxx>
+
+static const char fastbuildGeneratorName[] = "Fastbuild";
+
+class cmGlobalFastbuildGenerator::Factory : public cmGlobalGeneratorFactory
+{
+public:
+  Factory() {}
+
+  cmGlobalGenerator* CreateGlobalGenerator(const std::string& name) const
+  {
+    if (name == (fastbuildGeneratorName)) {
+      return new cmGlobalFastbuildGenerator();
+    }
+    return NULL;
+  }
+
+  void GetDocumentation(cmDocumentationEntry& entry) const
+  {
+    entry.Name = fastbuildGeneratorName;
+    entry.Brief = "Generates fastbuild project files.";
+  }
+
+  void GetGenerators(std::vector<std::string>& names) const
+  {
+    names.push_back(fastbuildGeneratorName);
+  }
+};
+
+//----------------------------------------------------------------------------
+class cmGlobalFastbuildGenerator::Detail
+{
+public:
+  class FileContext;
+  class Definition;
+  class Detection;
+  class Generation;
+};
+
+//----------------------------------------------------------------------------
+class cmGlobalFastbuildGenerator::Detail::FileContext
+{
+public:
+  FileContext(cmGeneratedFileStream& afout)
+    : fout(afout)
+  {
+  }
+
+  void WriteComment(const std::string& comment)
+  {
+    fout << linePrefix << ";" << comment << "\n";
+  }
+
+  void WriteBlankLine() { fout << "\n"; }
+
+  void WriteHorizontalLine()
+  {
+    fout << ";----------------------------------------------------------------"
+            "---------------\n";
+  }
+
+  void WriteSectionHeader(const char* section)
+  {
+    fout << "\n";
+    WriteHorizontalLine();
+    WriteComment(section);
+    WriteHorizontalLine();
+  }
+
+  void WritePushScope(char begin = '{', char end = '}')
+  {
+    fout << linePrefix << begin << "\n";
+    linePrefix += "\t";
+    closingScope += end;
+  }
+
+  void WritePushScopeStruct() { WritePushScope('[', ']'); }
+
+  void WritePopScope()
+  {
+    assert(!linePrefix.empty());
+    linePrefix.resize(linePrefix.size() - 1);
+
+    fout << linePrefix << closingScope[closingScope.size() - 1] << "\n";
+
+    closingScope.resize(closingScope.size() - 1);
+  }
+
+  void WriteVariable(const std::string& key, const std::string& value,
+                     const std::string& operation = "=")
+  {
+    fout << linePrefix << "." << key << " " << operation << " " << value
+         << "\n";
+  }
+
+  void WriteCommand(const std::string& command,
+                    const std::string& value = std::string())
+  {
+    fout << linePrefix << command;
+    if (!value.empty()) {
+      fout << "(" << value << ")";
+    }
+    fout << "\n";
+  }
+
+  void WriteArray(const std::string& key,
+                  const std::vector<std::string>& values,
+                  const std::string& operation = "=")
+  {
+    WriteVariable(key, "", operation);
+    WritePushScope();
+    int size = values.size();
+    for (int index = 0; index < size; ++index) {
+      const std::string& value = values[index];
+      bool isLast = index == size - 1;
+
+      fout << linePrefix << value;
+      if (!isLast) {
+        fout << ',';
+      }
+      fout << "\n";
+    }
+    WritePopScope();
+  }
+
+private:
+  cmGeneratedFileStream& fout;
+  std::string linePrefix;
+  std::string closingScope;
+};
+
+//----------------------------------------------------------------------------
+class cmGlobalFastbuildGenerator::Detail::Detection
+{
+public:
+  static std::string BuildCommandLine(const std::vector<std::string>& cmdLines)
+  {
+#ifdef _WIN32
+    const char* cmdExe = "cmd.exe";
+    std::string cmdExeAbsolutePath = cmSystemTools::FindProgram(cmdExe);
+#endif
+
+    // If we have no commands but we need to build a command anyway, use ":".
+    // This happens when building a POST_BUILD value for link targets that
+    // don't use POST_BUILD.
+    if (cmdLines.empty()) {
+#ifdef _WIN32
+      return cmdExeAbsolutePath + " /C \"cd .\"";
+#else
+      return ":";
+#endif
+    }
+
+    std::ostringstream cmd;
+    for (std::vector<std::string>::const_iterator li = cmdLines.begin();
+         li != cmdLines.end(); ++li)
+#ifdef _WIN32
+    {
+      if (li != cmdLines.begin()) {
+        cmd << " && ";
+      } else if (cmdLines.size() > 1) {
+        cmd << cmdExeAbsolutePath << " /C \"";
+      }
+      cmd << *li;
+    }
+    if (cmdLines.size() > 1) {
+      cmd << "\"";
+    }
+#else
+    {
+      if (li != cmdLines.begin()) {
+        cmd << " && ";
+      }
+      cmd << *li;
+    }
+#endif
+    std::string cmdOut = cmd.str();
+
+    // Unescape the Fastbuild configName symbol with $
+    cmSystemTools::ReplaceString(cmdOut, "$$ConfigName$$", "$ConfigName$");
+
+    return cmdOut;
+  }
+
+  static void DetectConfigurations(cmGlobalFastbuildGenerator* self,
+                                   cmMakefile* mf,
+                                   std::vector<std::string>& configurations)
+  {
+    // process the configurations
+    const char* configList =
+      self->CMakeInstance->GetCacheDefinition("CMAKE_CONFIGURATION_TYPES");
+    if (configList) {
+      std::vector<std::string> argsOut;
+      cmSystemTools::ExpandListArgument(configList, argsOut);
+      for (std::vector<std::string>::iterator iter = argsOut.begin();
+           iter != argsOut.end(); ++iter) {
+        if (std::find(configurations.begin(), configurations.end(), *iter) ==
+            configurations.end()) {
+          configurations.push_back(*iter);
+        }
+      }
+    }
+
+    // default to at least Debug and Release
+    if (configurations.size() == 0) {
+      configurations.push_back("Debug");
+      configurations.push_back("Release");
+    }
+
+    // Reset the entry to have a semi-colon separated list.
+    std::string configs = configurations[0];
+    for (unsigned int i = 1; i < configurations.size(); ++i) {
+      configs += ";";
+      configs += configurations[i];
+    }
+
+    // Add a cache definition
+    mf->AddCacheDefinition(
+      "CMAKE_CONFIGURATION_TYPES", configs.c_str(),
+      "Semicolon separated list of supported configuration types, "
+      "only supports Debug, Release, MinSizeRel, and RelWithDebInfo, "
+      "anything else will be ignored.",
+      cmCacheManager::STRING);
+  }
+
+  struct FastbuildTargetNames
+  {
+    std::string targetNameOut;
+    std::string targetNameReal;
+    std::string targetNameImport;
+    std::string targetNamePDB;
+    std::string targetNameSO;
+
+    std::string targetOutput;
+    std::string targetOutputReal;
+    std::string targetOutputImplib;
+    std::string targetOutputDir;
+  };
+
+  static void DetectOutput(FastbuildTargetNames& targetNamesOut,
+                           cmLocalFastbuildGenerator* lg, cmTarget& target,
+                           const std::string& configName)
+  {
+    if (target.GetType() == cmTarget::EXECUTABLE) {
+      target.GetExecutableNames(targetNamesOut.targetNameOut,
+                                targetNamesOut.targetNameReal,
+                                targetNamesOut.targetNameImport,
+                                targetNamesOut.targetNamePDB, configName);
+    } else {
+      target.GetLibraryNames(
+        targetNamesOut.targetNameOut, targetNamesOut.targetNameSO,
+        targetNamesOut.targetNameReal, targetNamesOut.targetNameImport,
+        targetNamesOut.targetNamePDB, configName);
+    }
+
+    if (target.HaveWellDefinedOutputFiles()) {
+      targetNamesOut.targetOutputDir = target.GetDirectory(configName) + "/";
+
+      targetNamesOut.targetOutput = target.GetFullPath(configName);
+      targetNamesOut.targetOutputReal = target.GetFullPath(configName,
+                                                           /*implib=*/false,
+                                                           /*realpath=*/true);
+      targetNamesOut.targetOutputImplib = target.GetFullPath(configName,
+                                                             /*implib=*/true);
+    } else {
+      targetNamesOut.targetOutputDir =
+        target.GetMakefile()->GetStartOutputDirectory();
+      if (targetNamesOut.targetOutputDir.empty() ||
+          targetNamesOut.targetOutputDir == ".") {
+        targetNamesOut.targetOutputDir = target.GetName();
+      } else {
+        targetNamesOut.targetOutputDir += "/";
+        targetNamesOut.targetOutputDir += target.GetName();
+      }
+      targetNamesOut.targetOutputDir += "/";
+      targetNamesOut.targetOutputDir += configName;
+      targetNamesOut.targetOutputDir += "/";
+
+      targetNamesOut.targetOutput =
+        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameOut;
+      targetNamesOut.targetOutputImplib =
+        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameImport;
+      targetNamesOut.targetOutputReal =
+        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameReal;
+    }
+
+    // Make sure all obey the correct slashes
+    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutput);
+    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputImplib);
+    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputReal);
+    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputDir);
+  }
+
+  static void ComputeLinkCmds(std::vector<std::string>& linkCmds,
+                              cmLocalFastbuildGenerator* lg, cmTarget& target,
+                              cmGeneratorTarget* gt, std::string configName)
+  {
+    const std::string& linkLanguage = target.GetLinkerLanguage(configName);
+    cmMakefile* mf = lg->GetMakefile();
+    {
+      std::string linkCmdVar =
+        gt->GetCreateRuleVariable(linkLanguage, configName);
+      const char* linkCmd = mf->GetDefinition(linkCmdVar);
+      if (linkCmd) {
+        cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+        return;
+      }
+    }
+
+    // If the above failed, then lets try this:
+    switch (target.GetType()) {
+      case cmTarget::STATIC_LIBRARY: {
+        // We have archive link commands set. First, delete the existing
+        // archive.
+        {
+          std::string cmakeCommand = lg->ConvertToOutputFormat(
+            mf->GetRequiredDefinition("CMAKE_COMMAND"),
+            cmLocalGenerator::SHELL);
+          linkCmds.push_back(cmakeCommand + " -E remove $TARGET_FILE");
+        }
+        // TODO: Use ARCHIVE_APPEND for archives over a certain size.
+        {
+          std::string linkCmdVar = "CMAKE_";
+          linkCmdVar += linkLanguage;
+          linkCmdVar += "_ARCHIVE_CREATE";
+          const char* linkCmd = mf->GetRequiredDefinition(linkCmdVar);
+          cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+        }
+        {
+          std::string linkCmdVar = "CMAKE_";
+          linkCmdVar += linkLanguage;
+          linkCmdVar += "_ARCHIVE_FINISH";
+          const char* linkCmd = mf->GetRequiredDefinition(linkCmdVar);
+          cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
+        }
+        return;
+      }
+      case cmTarget::SHARED_LIBRARY:
+      case cmTarget::MODULE_LIBRARY:
+      case cmTarget::EXECUTABLE:
+        break;
+      default:
+        assert(0 && "Unexpected target type");
+    }
+    return;
+  }
+
+  static std::string ComputeDefines(cmLocalFastbuildGenerator* lg,
+                                    cmTarget& target,
+                                    const cmSourceFile* source,
+                                    const std::string& configName,
+                                    const std::string& language)
+  {
+    std::set<std::string> defines;
+
+    // Add the export symbol definition for shared library objects.
+    if (const char* exportMacro = target.GetExportMacro()) {
+      lg->AppendDefines(defines, exportMacro);
+    }
+
+    // Add preprocessor definitions for this target and configuration.
+    lg->AddCompileDefinitions(defines, &target, configName, language);
+
+    if (source) {
+      lg->AppendDefines(defines, source->GetProperty("COMPILE_DEFINITIONS"));
+
+      std::string defPropName = "COMPILE_DEFINITIONS_";
+      defPropName += cmSystemTools::UpperCase(configName);
+      lg->AppendDefines(defines, source->GetProperty(defPropName));
+    }
+
+    // Add a definition for the configuration name.
+    // NOTE: CMAKE_TEST_REQUIREMENT The following was added specifically to
+    // facillitate cmake testing. Doesn't feel right to do this...
+    std::string configDefine = "CMAKE_INTDIR=\"";
+    configDefine += configName;
+    configDefine += "\"";
+    lg->AppendDefines(defines, configDefine);
+
+    std::string definesString;
+    lg->JoinDefines(defines, definesString, language);
+
+    return definesString;
+  }
+
+  static void DetectLinkerLibPaths(std::string& linkerLibPath,
+                                   cmLocalFastbuildGenerator* lg,
+                                   cmTarget& target,
+                                   const std::string& configName)
+  {
+    cmMakefile* pMakefile = lg->GetMakefile();
+    cmComputeLinkInformation* pcli = target.GetLinkInformation(configName);
+    if (!pcli) {
+      // No link information, then no linker library paths
+      return;
+    }
+    cmComputeLinkInformation& cli = *pcli;
+
+    std::string libPathFlag =
+      pMakefile->GetRequiredDefinition("CMAKE_LIBRARY_PATH_FLAG");
+    std::string libPathTerminator =
+      pMakefile->GetSafeDefinition("CMAKE_LIBRARY_PATH_TERMINATOR");
+
+    // Append the library search path flags.
+    std::vector<std::string> const& libDirs = cli.GetDirectories();
+    for (std::vector<std::string>::const_iterator libDir = libDirs.begin();
+         libDir != libDirs.end(); ++libDir) {
+      std::string libpath = lg->ConvertToOutputForExisting(
+        *libDir, cmLocalGenerator::START_OUTPUT, cmLocalGenerator::SHELL);
+      cmSystemTools::ConvertToOutputSlashes(libpath);
+
+      // Add the linker lib path twice, once raw, then once with
+      // the configname attached
+      std::string configlibpath = libpath + "/" + configName;
+      cmSystemTools::ConvertToOutputSlashes(configlibpath);
+
+      linkerLibPath += " " + libPathFlag;
+      linkerLibPath += libpath;
+      linkerLibPath += libPathTerminator;
+
+      linkerLibPath += " " + libPathFlag;
+      linkerLibPath += configlibpath;
+      linkerLibPath += libPathTerminator;
+      linkerLibPath += " ";
+    }
+  }
+
+  static bool DetectBaseLinkerCommand(std::string& command,
+                                      cmLocalFastbuildGenerator* lg,
+                                      cmTarget& target, cmGeneratorTarget* gt,
+                                      const std::string& configName)
+  {
+    const std::string& linkLanguage = target.GetLinkerLanguage(configName);
+    if (linkLanguage.empty()) {
+      cmSystemTools::Error("CMake can not determine linker language for "
+                           "target: ",
+                           target.GetName().c_str());
+      return false;
+    }
+
+    cmTarget::TargetType targetType = target.GetType();
+
+    cmLocalGenerator::RuleVariables vars;
+    vars.RuleLauncher = "RULE_LAUNCH_LINK";
+    vars.CMTarget = &target;
+    vars.Language = linkLanguage.c_str();
+
+    std::string responseFlag;
+    vars.Objects = "%1";
+    vars.LinkLibraries = "";
+
+    vars.ObjectDir = "$TargetOutDir$";
+    vars.Target = "%2";
+
+    vars.TargetSOName = "$TargetOutSO$";
+    vars.TargetPDB = "$TargetOutDir$$TargetNamePDB$";
+
+    // Setup the target version.
+    std::string targetVersionMajor;
+    std::string targetVersionMinor;
+    {
+      std::ostringstream majorStream;
+      std::ostringstream minorStream;
+      int major;
+      int minor;
+      target.GetTargetVersion(major, minor);
+      majorStream << major;
+      minorStream << minor;
+      targetVersionMajor = majorStream.str();
+      targetVersionMinor = minorStream.str();
+    }
+    vars.TargetVersionMajor = targetVersionMajor.c_str();
+    vars.TargetVersionMinor = targetVersionMinor.c_str();
+
+    vars.Defines = "$CompileDefineFlags$";
+    vars.Flags = "$CompileFlags$";
+    vars.LinkFlags = "$LinkFlags$ $LinkPath$";
+    // Rule for linking library/executable.
+    std::vector<std::string> linkCmds;
+    ComputeLinkCmds(linkCmds, lg, target, gt, configName);
+    for (std::vector<std::string>::iterator i = linkCmds.begin();
+         i != linkCmds.end(); ++i) {
+      lg->ExpandRuleVariables(*i, vars);
+    }
+
+    command = BuildCommandLine(linkCmds);
+
+    return true;
+  }
+
+  static void SplitExecutableAndFlags(const std::string& command,
+                                      std::string& executable,
+                                      std::string& options)
+  {
+    // Remove the command from the front
+    std::vector<std::string> args =
+      cmSystemTools::ParseArguments(command.c_str());
+
+    // Join the args together and remove 0 from the front
+    std::stringstream argSet;
+    std::copy(args.begin() + 1, args.end(),
+              std::ostream_iterator<std::string>(argSet, " "));
+
+    executable = args[0];
+    options = argSet.str();
+  }
+
+  static void DetectBaseCompileCommand(std::string& command,
+                                       cmLocalFastbuildGenerator* lg,
+                                       cmTarget& target,
+                                       const std::string& language)
+  {
+    cmLocalGenerator::RuleVariables compileObjectVars;
+    compileObjectVars.CMTarget = &target;
+    compileObjectVars.Language = language.c_str();
+    compileObjectVars.Source = "%1";
+    compileObjectVars.Object = "%2";
+    compileObjectVars.ObjectDir = "$TargetOutputDir$";
+    compileObjectVars.ObjectFileDir = "";
+    compileObjectVars.Flags = "";
+    compileObjectVars.Defines = "";
+    compileObjectVars.TargetCompilePDB = "$TargetNamePDB$";
+
+    // Rule for compiling object file.
+    std::string compileCmdVar = "CMAKE_";
+    compileCmdVar += language;
+    compileCmdVar += "_COMPILE_OBJECT";
+    std::string compileCmd =
+      lg->GetMakefile()->GetRequiredDefinition(compileCmdVar);
+    std::vector<std::string> compileCmds;
+    cmSystemTools::ExpandListArgument(compileCmd, compileCmds);
+
+    for (std::vector<std::string>::iterator i = compileCmds.begin();
+         i != compileCmds.end(); ++i) {
+      std::string& compileCmd = *i;
+      lg->ExpandRuleVariables(compileCmd, compileObjectVars);
+    }
+
+    command = BuildCommandLine(compileCmds);
+  }
+
+  static std::string DetectCompileRule(cmLocalFastbuildGenerator* lg,
+                                       cmTarget& target,
+                                       const std::string& lang)
+  {
+    cmLocalGenerator::RuleVariables vars;
+    vars.RuleLauncher = "RULE_LAUNCH_COMPILE";
+    vars.CMTarget = &target;
+    vars.Language = lang.c_str();
+    vars.Source = "$in";
+    vars.Object = "$out";
+    vars.Defines = "$DEFINES";
+    vars.TargetPDB = "$TARGET_PDB";
+    vars.TargetCompilePDB = "$TARGET_COMPILE_PDB";
+    vars.ObjectDir = "$OBJECT_DIR";
+    vars.ObjectFileDir = "$OBJECT_FILE_DIR";
+    vars.Flags = "$FLAGS";
+
+    cmMakefile* mf = lg->GetMakefile();
+
+    // Rule for compiling object file.
+    const std::string cmdVar =
+      std::string("CMAKE_") + lang + "_COMPILE_OBJECT";
+    std::string compileCmd = mf->GetRequiredDefinition(cmdVar);
+    std::vector<std::string> compileCmds;
+    cmSystemTools::ExpandListArgument(compileCmd, compileCmds);
+
+    for (std::vector<std::string>::iterator i = compileCmds.begin();
+         i != compileCmds.end(); ++i) {
+      lg->ExpandRuleVariables(*i, vars);
+    }
+
+    std::string cmdLine = BuildCommandLine(compileCmds);
+
+    return cmdLine;
+  }
+
+  static void DetectLanguages(std::set<std::string>& languages,
+                              cmGlobalFastbuildGenerator* self,
+                              cmTarget& target)
+  {
+    // Object libraries do not have linker stages
+    // nor utilities
+    bool hasObjectGroups = target.GetType() != cmTarget::UTILITY &&
+      target.GetType() != cmTarget::GLOBAL_TARGET;
+    if (!hasObjectGroups) {
+      return;
+    }
+
+    cmGeneratorTarget* gt = self->GetGeneratorTarget(&target);
+
+    for (std::vector<std::string>::iterator iter =
+           self->Configurations.begin();
+         iter != self->Configurations.end(); ++iter) {
+      std::string& configName = *iter;
+
+      std::vector<cmSourceFile*> sourceFiles;
+      gt->GetSourceFiles(sourceFiles, configName);
+      for (std::vector<cmSourceFile*>::const_iterator i = sourceFiles.begin();
+           i != sourceFiles.end(); ++i) {
+        const std::string& lang = (*i)->GetLanguage();
+        if (!lang.empty()) {
+          languages.insert(lang);
+        }
+      }
+    }
+  }
+
+  static void FilterSourceFiles(
+    std::vector<cmSourceFile const*>& filteredSourceFiles,
+    std::vector<cmSourceFile const*>& sourceFiles, const std::string& language)
+  {
+    for (std::vector<cmSourceFile const*>::const_iterator i =
+           sourceFiles.begin();
+         i != sourceFiles.end(); ++i) {
+      const cmSourceFile* sf = *i;
+      if (sf->GetLanguage() == language) {
+        filteredSourceFiles.push_back(sf);
+      }
+    }
+  }
+
+  static void DetectCompilerFlags(std::string& compileFlags,
+                                  cmLocalFastbuildGenerator* lg,
+                                  cmGeneratorTarget* gt, cmTarget& target,
+                                  const cmSourceFile* source,
+                                  const std::string& language,
+                                  const std::string& configName)
+  {
+    lg->AddLanguageFlags(compileFlags, language, configName);
+
+    lg->AddArchitectureFlags(compileFlags, gt, language, configName);
+
+    // Add shared-library flags if needed.
+    lg->AddCMP0018Flags(compileFlags, &target, language, configName);
+
+    lg->AddVisibilityPresetFlags(compileFlags, &target, language);
+
+    std::vector<std::string> includes;
+    lg->GetIncludeDirectories(includes, gt, language, configName);
+
+    // Add include directory flags.
+    std::string includeFlags = lg->GetIncludeFlags(
+      includes, gt, language,
+      language == "RC" ? true : false, // full include paths for RC
+      // needed by cmcldeps
+      false, configName);
+
+    lg->AppendFlags(compileFlags, includeFlags);
+
+    // Append old-style preprocessor definition flags.
+    lg->AppendFlags(compileFlags, lg->GetMakefile()->GetDefineFlags());
+
+    // Add target-specific flags.
+    lg->AddCompileOptions(compileFlags, &target, language, configName);
+
+    if (source) {
+      lg->AppendFlags(compileFlags, source->GetProperty("COMPILE_FLAGS"));
+    }
+  }
+
+  static void DetectTargetCompileDependencies(
+    cmGlobalFastbuildGenerator* gg, cmTarget& target,
+    std::vector<std::string>& dependencies)
+  {
+    if (target.GetType() == cmTarget::GLOBAL_TARGET) {
+      // Global targets only depend on other utilities, which may not appear in
+      // the TargetDepends set (e.g. "all").
+      std::set<std::string> const& utils = target.GetUtilities();
+      std::copy(utils.begin(), utils.end(), std::back_inserter(dependencies));
+    } else {
+      cmTargetDependSet const& targetDeps = gg->GetTargetDirectDepends(target);
+      for (cmTargetDependSet::const_iterator i = targetDeps.begin();
+           i != targetDeps.end(); ++i) {
+        const cmTargetDepend& depTarget = *i;
+        if (depTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
+          continue;
+        }
+        dependencies.push_back(depTarget->GetName());
+      }
+    }
+  }
+
+  static void DetectTargetLinkDependencies(
+    cmGlobalFastbuildGenerator* gg, cmTarget& target,
+    const std::string& configName, std::vector<std::string>& dependencies)
+  {
+    // Static libraries never depend on other targets for linking.
+    if (target.GetType() == cmTarget::STATIC_LIBRARY ||
+        target.GetType() == cmTarget::OBJECT_LIBRARY) {
+      return;
+    }
+
+    cmComputeLinkInformation* cli = target.GetLinkInformation(configName);
+    if (!cli) {
+      return;
+    }
+
+    const std::vector<std::string>& deps = cli->GetDepends();
+    std::copy(deps.begin(), deps.end(), std::back_inserter(dependencies));
+  }
+
+  static std::string DetectTargetCompileOutputDir(
+    cmLocalFastbuildGenerator* lg, const cmTarget& target,
+    std::string configName)
+  {
+    std::string result = lg->GetTargetDirectory(target) + "/";
+    if (!configName.empty()) {
+      result = result + configName + "/";
+    }
+    cmSystemTools::ConvertToOutputSlashes(result);
+    return result;
+  }
+
+  static void DetectTargetObjectDependencies(
+    cmGlobalFastbuildGenerator* gg, cmTarget& target,
+    const std::string& configName, std::vector<std::string>& dependencies)
+  {
+    // Iterate over all source files and look for
+    // object file dependencies
+    cmGeneratorTarget* gt = gg->GetGeneratorTarget(&target);
+
+    std::set<std::string> objectLibs;
+
+    std::vector<cmSourceFile*> sourceFiles;
+    gt->GetSourceFiles(sourceFiles, configName);
+    for (std::vector<cmSourceFile*>::const_iterator i = sourceFiles.begin();
+         i != sourceFiles.end(); ++i) {
+      const std::string& objectLib = (*i)->GetObjectLibrary();
+      if (!objectLib.empty()) {
+        // Find the target this actually is (might be an alias)
+        const cmTarget* objectTarget = gg->FindTarget(objectLib);
+        if (objectTarget) {
+          objectLibs.insert(objectTarget->GetName() + "-" + configName +
+                            "-products");
+        }
+      }
+    }
+
+    std::copy(objectLibs.begin(), objectLibs.end(),
+              std::back_inserter(dependencies));
+
+    // Now add the external obj files that also need to be linked in
+    std::vector<const cmSourceFile*> objFiles;
+    gt->GetExternalObjects(objFiles, configName);
+    for (std::vector<const cmSourceFile*>::const_iterator i = objFiles.begin();
+         i != objFiles.end(); ++i) {
+      const cmSourceFile* sourceFile = *i;
+      if (sourceFile->GetObjectLibrary().empty()) {
+        dependencies.push_back(sourceFile->GetFullPath());
+      }
+    }
+  }
+
+  struct DependencySorter
+  {
+    struct TargetHelper
+    {
+      cmGlobalFastbuildGenerator* gg;
+
+      void GetOutputs(const cmTarget* entry, std::vector<std::string>& outputs)
+      {
+        outputs.push_back(entry->GetName());
+      }
+
+      void GetInputs(const cmTarget* entry, std::vector<std::string>& inputs)
+      {
+        TargetDependSet const& ts = gg->GetTargetDirectDepends(*entry);
+        for (TargetDependSet::const_iterator iter = ts.begin();
+             iter != ts.end(); ++iter) {
+          const cmTarget* dtarget = *iter;
+          inputs.push_back(dtarget->GetName());
+        }
+      }
+    };
+
+    struct CustomCommandHelper
+    {
+      cmGlobalFastbuildGenerator* gg;
+      cmLocalFastbuildGenerator* lg;
+      const std::string& configName;
+
+      void GetOutputs(const cmSourceFile* entry,
+                      std::vector<std::string>& outputs)
+      {
+        const cmCustomCommand* cc = entry->GetCustomCommand();
+        cmMakefile* makefile = lg->GetMakefile();
+
+        // We need to generate the command for execution.
+        cmCustomCommandGenerator ccg(*cc, configName, makefile);
+
+        const std::vector<std::string>& ccOutputs = ccg.GetOutputs();
+        const std::vector<std::string>& byproducts = ccg.GetByproducts();
+        outputs.insert(outputs.end(), ccOutputs.begin(), ccOutputs.end());
+        outputs.insert(outputs.end(), byproducts.begin(), byproducts.end());
+      }
+
+      void GetInputs(const cmSourceFile* entry,
+                     std::vector<std::string>& inputs)
+      {
+        const cmCustomCommand* cc = entry->GetCustomCommand();
+        cmMakefile* makefile = lg->GetMakefile();
+        cmCustomCommandGenerator ccg(*cc, configName, makefile);
+
+        // Take the dependencies listed and split into targets and files.
+        const std::vector<std::string>& depends = ccg.GetDepends();
+        for (std::vector<std::string>::const_iterator iter = depends.begin();
+             iter != depends.end(); ++iter) {
+          const std::string& dep = *iter;
+
+          bool isTarget = gg->FindTarget(dep) != NULL;
+          if (!isTarget) {
+            inputs.push_back(dep);
+          }
+        }
+      }
+    };
+
+    template <class TType, class TTypeHelper>
+    static void Sort(TTypeHelper& helper, std::vector<const TType*>& entries)
+    {
+      typedef std::vector<std::string> StringVector;
+      typedef std::vector<const TType*> OrderedEntrySet;
+      typedef std::map<std::string, const TType*> OutputMap;
+      typedef std::map<const TType*, StringVector> DependencyMap;
+
+      // Build up a map of outputNames to entries
+      OutputMap outputMap;
+      for (OrderedEntrySet::iterator iter = entries.begin();
+           iter != entries.end(); ++iter) {
+        const TType* entry = *iter;
+        StringVector outputs;
+        helper.GetOutputs(entry, outputs);
+
+        for (StringVector::iterator outIter = outputs.begin();
+             outIter != outputs.end(); ++outIter) {
+          outputMap[*outIter] = entry;
+        }
+      }
+
+      // Now build a forward and reverse map of dependencies
+      // Build the reverse graph,
+      // each target, and the set of things that depend upon it
+      typedef std::map<const TType*, std::vector<const TType*> > DepMap;
+      DepMap forwardDeps;
+      DepMap reverseDeps;
+      for (OrderedEntrySet::iterator iter = entries.begin();
+           iter != entries.end(); ++iter) {
+        const TType* entry = *iter;
+        std::vector<const TType*>& entryInputs = forwardDeps[entry];
+
+        StringVector inputs;
+        helper.GetInputs(entry, inputs);
+        for (StringVector::const_iterator inIter = inputs.begin();
+             inIter != inputs.end(); ++inIter) {
+          const std::string& input = *inIter;
+          // Lookup the input in the output map and find the right entry
+          OutputMap::iterator findResult = outputMap.find(input);
+          if (findResult != outputMap.end()) {
+            const TType* dentry = findResult->second;
+            entryInputs.push_back(dentry);
+            reverseDeps[dentry].push_back(entry);
+          }
+        }
+      }
+
+      // We have all the information now.
+      // Clear the array passed in
+      entries.clear();
+
+      // Now iterate over each target with its list of dependencies.
+      // And dump out ones that have 0 dependencies.
+      bool written = true;
+      while (!forwardDeps.empty() && written) {
+        written = false;
+        for (DepMap::iterator iter = forwardDeps.begin();
+             iter != forwardDeps.end(); ++iter) {
+          std::vector<const TType*>& fwdDeps = iter->second;
+          const TType* entry = iter->first;
+          if (!fwdDeps.empty()) {
+            // Looking for empty dependency lists.
+            // Those are the next to be written out
+            continue;
+          }
+
+          // dependency list is empty,
+          // add it to the output list
+          written = true;
+          entries.push_back(entry);
+
+          // Use reverse dependencies to determine
+          // what forward dep lists to adjust
+          std::vector<const TType*>& revDeps = reverseDeps[entry];
+          for (unsigned int i = 0; i < revDeps.size(); ++i) {
+            const TType* revDep = revDeps[i];
+
+            // Fetch the list of deps on that target
+            std::vector<const TType*>& revDepFwdDeps = forwardDeps[revDep];
+            // remove the one we just added from the list
+            revDepFwdDeps.erase(
+              std::remove(revDepFwdDeps.begin(), revDepFwdDeps.end(), entry),
+              revDepFwdDeps.end());
+          }
+
+          // Remove it from forward deps so not
+          // considered again
+          forwardDeps.erase(entry);
+
+          // Must break now as we've invalidated
+          // our forward deps iterator
+          break;
+        }
+      }
+
+      // Validation...
+      // Make sure we managed to find a place
+      // to insert every dependency.
+      // If this fires, then there is most likely
+      // a cycle in the graph...
+      assert(forwardDeps.empty());
+    }
+  };
+
+  typedef std::vector<const cmTarget*> OrderedTargetSet;
+  static void ComputeTargetOrderAndDependencies(
+    cmGlobalFastbuildGenerator* gg, OrderedTargetSet& orderedTargets)
+  {
+    TargetDependSet projectTargets;
+    TargetDependSet originalTargets;
+    std::map<std::string, std::vector<cmLocalGenerator*> >::iterator it;
+    for (it = gg->ProjectMap.begin(); it != gg->ProjectMap.end(); ++it) {
+      std::vector<cmLocalGenerator*>& generators = it->second;
+      cmLocalFastbuildGenerator* root =
+        static_cast<cmLocalFastbuildGenerator*>(generators[0]);
+
+      // Given this information, calculate the dependencies:
+      // Collect all targets under this root generator and the transitive
+      // closure of their dependencies.
+
+      gg->GetTargetSets(projectTargets, originalTargets, root, generators);
+    }
+
+    // Iterate over the targets and export their order
+    for (TargetDependSet::iterator iter = projectTargets.begin();
+         iter != projectTargets.end(); ++iter) {
+      const cmTargetDepend& targetDepend = *iter;
+      const cmTarget& target = *targetDepend;
+
+      orderedTargets.push_back(&target);
+    }
+
+    DependencySorter::TargetHelper targetHelper = { gg };
+    DependencySorter::Sort(targetHelper, orderedTargets);
+  }
+
+  static void StripNestedGlobalTargets(OrderedTargetSet& orderedTargets)
+  {
+    // Iterate over all targets and remove the ones that are
+    // not needed for generation.
+    // i.e. the nested global targets
+    struct RemovalTest
+    {
+      bool operator()(const cmTarget* target) const
+      {
+        if (target->GetType() == cmTarget::GLOBAL_TARGET) {
+          // We only want to process global targets that live in the home
+          // (i.e. top-level) directory.  CMake creates copies of these targets
+          // in every directory, which we don't need.
+          cmMakefile* mf = target->GetMakefile();
+          if (strcmp(mf->GetStartDirectory(), mf->GetHomeDirectory()) != 0) {
+            return true;
+          }
+        }
+        return false;
+      }
+    };
+
+    orderedTargets.erase(std::remove_if(orderedTargets.begin(),
+                                        orderedTargets.end(), RemovalTest()),
+                         orderedTargets.end());
+  }
+
+  static bool isConfigDependant(const cmCustomCommandGenerator& ccg)
+  {
+    typedef std::vector<std::string> StringVector;
+    const StringVector& outputs = ccg.GetOutputs();
+    const StringVector& byproducts = ccg.GetByproducts();
+
+    // Make sure that the outputs don't depend on the config name
+    for (StringVector::const_iterator iter = outputs.begin();
+         iter != outputs.end(); ++iter) {
+      const std::string& str = *iter;
+      if (str.find("$ConfigName$") != std::string::npos) {
+        return true;
+      }
+    }
+    for (StringVector::const_iterator iter = byproducts.begin();
+         iter != byproducts.end(); ++iter) {
+      const std::string& str = *iter;
+      if (str.find("$ConfigName$") != std::string::npos) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+private:
+};
+
+//----------------------------------------------------------------------------
+class cmGlobalFastbuildGenerator::Detail::Definition
+{
+  struct FastbuildSettings
+  {
+    std::string cachePath;
+  };
+
+  struct FastbuildCompiler
+  {
+    std::string executable;
+  };
+  typedef std::map<std::string, FastbuildCompiler> CompilerMap;
+
+  struct FastbuildConfiguration
+  {
+    std::string name;
+  };
+  typedef std::map<std::string, FastbuildConfiguration> ConfigurationMap;
+
+  struct FastbuildStructure
+  {
+    ConfigurationMap configurations;
+
+    FastbuildSettings settings;
+    CompilerMap compilers;
+  };
+};
+
+//----------------------------------------------------------------------------
+class cmGlobalFastbuildGenerator::Detail::Generation
+{
+public:
+  struct TargetGenerationContext
+  {
+    cmTarget* target;
+    cmLocalFastbuildGenerator* root;
+    std::vector<cmLocalGenerator*> generators;
+    cmLocalFastbuildGenerator* lg;
+  };
+  typedef std::map<const cmTarget*, TargetGenerationContext> TargetContextMap;
+  typedef std::map<const cmCustomCommand*, std::string> CustomCommandAliasMap;
+  typedef Detection::OrderedTargetSet OrderedTargets;
+
+  struct GenerationContext
+  {
+    cmGlobalFastbuildGenerator* self;
+    cmLocalFastbuildGenerator* root;
+    FileContext& fc;
+    OrderedTargets orderedTargets;
+    TargetContextMap targetContexts;
+    CustomCommandAliasMap customCommandAliases;
+  };
+
+  static std::string Quote(const std::string& str,
+                           const std::string& quotation = "'")
+  {
+    return quotation + str + quotation;
+  }
+
+  static std::string Join(const std::vector<std::string>& elems,
+                          const std::string& delim)
+  {
+    std::stringstream stringstream;
+    for (std::vector<std::string>::const_iterator iter = elems.begin();
+         iter != elems.end(); ++iter) {
+      stringstream << (*iter);
+      if (iter + 1 != elems.end()) {
+        stringstream << delim;
+      }
+    }
+
+    return stringstream.str();
+  }
+
+  static std::vector<std::string> Wrap(const std::vector<std::string>& in,
+                                       const std::string& prefix = "'",
+                                       const std::string& suffix = "'")
+  {
+    std::vector<std::string> result;
+
+    struct WrapHelper
+    {
+      std::string m_prefix;
+      std::string m_suffix;
+
+      std::string operator()(const std::string& in)
+      {
+        return m_prefix + in + m_suffix;
+      }
+    };
+
+    WrapHelper helper = { prefix, suffix };
+
+    std::transform(in.begin(), in.end(), std::back_inserter(result), helper);
+
+    return result;
+  }
+
+  static std::string EncodeLiteral(const std::string& lit)
+  {
+    std::string result = lit;
+    cmSystemTools::ReplaceString(result, "$", "^$");
+    return result;
+  }
+
+  static void EnsureDirectoryExists(const std::string& path,
+                                    GenerationContext& context)
+  {
+    if (cmSystemTools::FileIsFullPath(path.c_str())) {
+      cmSystemTools::MakeDirectory(path.c_str());
+    } else {
+      const std::string fullPath =
+        std::string(
+          context.self->GetCMakeInstance()->GetHomeOutputDirectory()) +
+        "/" + path;
+      cmSystemTools::MakeDirectory(fullPath.c_str());
+    }
+  }
+
+  static void BuildTargetContexts(cmGlobalFastbuildGenerator* gg,
+                                  TargetContextMap& map)
+  {
+    std::map<std::string, std::vector<cmLocalGenerator*> >::iterator it;
+    for (it = gg->ProjectMap.begin(); it != gg->ProjectMap.end(); ++it) {
+      std::vector<cmLocalGenerator*>& generators = it->second;
+      cmLocalFastbuildGenerator* root =
+        static_cast<cmLocalFastbuildGenerator*>(generators[0]);
+
+      // Build a map of all targets to their local generator
+      for (std::vector<cmLocalGenerator*>::iterator iter = generators.begin();
+           iter != generators.end(); ++iter) {
+        cmLocalFastbuildGenerator* lg =
+          static_cast<cmLocalFastbuildGenerator*>(*iter);
+
+        if (gg->IsExcluded(root, lg)) {
+          continue;
+        }
+
+        cmTargets& tgts = lg->GetMakefile()->GetTargets();
+        for (cmTargets::iterator targetIter = tgts.begin();
+             targetIter != tgts.end(); ++targetIter) {
+          cmTarget& target = (targetIter->second);
+
+          if (gg->IsRootOnlyTarget(&target) &&
+              target.GetMakefile() != root->GetMakefile()) {
+            continue;
+          }
+
+          TargetGenerationContext targetContext = { &target, root, generators,
+                                                    lg };
+          map[&target] = targetContext;
+        }
+      }
+    }
+  }
+
+  static void GenerateRootBFF(cmGlobalFastbuildGenerator* self)
+  {
+
+    cmLocalFastbuildGenerator* root =
+      static_cast<cmLocalFastbuildGenerator*>(self->GetLocalGenerators()[0]);
+
+    // Calculate filename
+    std::string fname = root->GetMakefile()->GetStartOutputDirectory();
+    fname += "/";
+    // fname += root->GetMakefile()->GetProjectName();
+    fname += "fbuild";
+    fname += ".bff";
+
+    // Open file
+    cmGeneratedFileStream fout(fname.c_str());
+    fout.SetCopyIfDifferent(true);
+    if (!fout) {
+      return;
+    }
+
+    FileContext fc(fout);
+    GenerationContext context = { self, root, fc };
+    Detection::ComputeTargetOrderAndDependencies(context.self,
+                                                 context.orderedTargets);
+    Detection::StripNestedGlobalTargets(context.orderedTargets);
+    BuildTargetContexts(context.self, context.targetContexts);
+    WriteRootBFF(context);
+
+    // Close file
+    if (fout.Close()) {
+      self->FileReplacedDuringGenerate(fname);
+    }
+  }
+
+  static void WriteRootBFF(GenerationContext& context)
+  {
+    context.fc.WriteSectionHeader(
+      "Fastbuild makefile - Generated using CMAKE");
+
+    WriteSettings(context);
+    WriteCompilers(context);
+    WriteConfigurations(context);
+
+    // Sort targets
+
+    WriteTargetDefinitions(context);
+    WriteAliases(context);
+  }
+
+  static void WriteSettings(GenerationContext& context)
+  {
+    context.fc.WriteSectionHeader("Settings");
+
+    context.fc.WriteCommand("Settings");
+    context.fc.WritePushScope();
+
+    std::string cacheDir =
+      context.self->GetCMakeInstance()->GetHomeOutputDirectory();
+    cacheDir += "\\.fbuild.cache";
+    cmSystemTools::ConvertToOutputSlashes(cacheDir);
+
+    context.fc.WriteVariable("CachePath", Quote(cacheDir));
+    context.fc.WritePopScope();
+  }
+
+  static bool WriteCompilers(GenerationContext& context)
+  {
+    cmMakefile* mf = context.root->GetMakefile();
+
+    context.fc.WriteSectionHeader("Compilers");
+
+    // Detect each language used in the definitions
+    std::set<std::string> languages;
+    for (TargetContextMap::iterator iter = context.targetContexts.begin();
+         iter != context.targetContexts.end(); ++iter) {
+      TargetGenerationContext& targetContext = iter->second;
+
+      if (targetContext.target->GetType() == cmTarget::INTERFACE_LIBRARY) {
+        continue;
+      }
+
+      Detection::DetectLanguages(languages, context.self,
+                                 *targetContext.target);
+    }
+
+    // Now output a compiler for each of these languages
+    typedef std::map<std::string, std::string> StringMap;
+    StringMap compilerToCompilerName;
+    StringMap languageToCompiler;
+    for (std::set<std::string>::iterator iter = languages.begin();
+         iter != languages.end(); ++iter) {
+      const std::string& language = *iter;
+
+      // Calculate the root location of the compiler
+      std::string variableString = "CMAKE_" + language + "_COMPILER";
+      std::string compilerLocation = mf->GetSafeDefinition(variableString);
+      if (compilerLocation.empty()) {
+        return false;
+      }
+
+      // Add the language to the compiler's name
+      std::string& compilerName = compilerToCompilerName[compilerLocation];
+      if (compilerName.empty()) {
+        compilerName = "Compiler";
+      }
+      compilerName += "-";
+      compilerName += language;
+
+      // Now add the language to point to that compiler location
+      languageToCompiler[language] = compilerLocation;
+    }
+
+    // Now output all the compilers
+    for (StringMap::iterator iter = compilerToCompilerName.begin();
+         iter != compilerToCompilerName.end(); ++iter) {
+      const std::string& compilerLocation = iter->first;
+      const std::string& compilerName = iter->second;
+
+      // Strip out the path to the compiler
+      std::string compilerPath =
+        cmSystemTools::GetFilenamePath(compilerLocation);
+      std::string compilerFile =
+        "$CompilerRoot$\\" + cmSystemTools::GetFilenameName(compilerLocation);
+
+      cmSystemTools::ConvertToOutputSlashes(compilerPath);
+      cmSystemTools::ConvertToOutputSlashes(compilerFile);
+
+      // Write out the compiler that has been configured
+      context.fc.WriteCommand("Compiler", Quote(compilerName));
+      context.fc.WritePushScope();
+      context.fc.WriteVariable("CompilerRoot", Quote(compilerPath));
+      context.fc.WriteVariable("Executable", Quote(compilerFile));
+      context.fc.WritePopScope();
+    }
+
+    // Now output the compiler names according to language as variables
+    for (StringMap::iterator iter = languageToCompiler.begin();
+         iter != languageToCompiler.end(); ++iter) {
+      const std::string& language = iter->first;
+      const std::string& compilerLocation = iter->second;
+      const std::string& compilerName =
+        compilerToCompilerName[compilerLocation];
+
+      // Output a default compiler to absorb the library requirements for a
+      // compiler
+      if (iter == languageToCompiler.begin()) {
+        context.fc.WriteVariable("Compiler_dummy", Quote(compilerName));
+      }
+
+      context.fc.WriteVariable("Compiler_" + language, Quote(compilerName));
+    }
+
+    return true;
+  }
+
+  static void WriteConfigurations(GenerationContext& context)
+  {
+    context.fc.WriteSectionHeader("Configurations");
+
+    context.fc.WriteVariable("ConfigBase", "");
+    context.fc.WritePushScopeStruct();
+    context.fc.WritePopScope();
+
+    // Iterate over all configurations and define them:
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string& configName = *iter;
+      context.fc.WriteVariable("config_" + configName, "");
+      context.fc.WritePushScopeStruct();
+
+      // Using base config
+      context.fc.WriteCommand("Using", ".ConfigBase");
+
+      context.fc.WritePopScope();
+    }
+
+    // Write out a list of all configs
+    context.fc.WriteArray("all_configs",
+                          Wrap(context.self->Configurations, ".config_", ""));
+  }
+
+  static std::string MakeCustomLauncher(cmLocalFastbuildGenerator* lg,
+                                        cmCustomCommandGenerator const& ccg)
+  {
+    const char* property = "RULE_LAUNCH_CUSTOM";
+    const char* property_value = lg->GetMakefile()->GetProperty(property);
+
+    if (!property_value || !*property_value) {
+      return std::string();
+    }
+
+    // Expand rules in the empty string.  It may insert the launcher and
+    // perform replacements.
+    cmLocalGenerator::RuleVariables vars;
+    vars.RuleLauncher = property;
+    std::string output;
+    const std::vector<std::string>& outputs = ccg.GetOutputs();
+    if (!outputs.empty()) {
+      cmLocalGenerator::RelativeRoot relative_root =
+        ccg.GetWorkingDirectory().empty() ? cmLocalGenerator::START_OUTPUT
+                                          : cmLocalGenerator::NONE;
+
+      output = lg->Convert(outputs[0], relative_root, cmLocalGenerator::SHELL);
+    }
+    vars.Output = output.c_str();
+
+    std::string launcher;
+    lg->ExpandRuleVariables(launcher, vars);
+    if (!launcher.empty()) {
+      launcher += " ";
+    }
+
+    return launcher;
+  }
+
+  struct SourceFileNameIs
+  {
+    SourceFileNameIs(const std::string& name)
+      : m_name(name)
+    {
+    }
+
+    std::string m_name;
+
+    bool operator()(const cmSourceFile* sf) const
+    {
+      return sf->GetFullPath() == m_name;
+    }
+  };
+
+  static void WriteCustomCommand(GenerationContext& context,
+                                 const cmCustomCommand* cc,
+                                 cmLocalFastbuildGenerator* lg,
+                                 cmTarget& target,
+                                 const std::string& configName,
+                                 const std::string& targetName)
+  {
+    cmMakefile* makefile = lg->GetMakefile();
+
+    // We need to generate the command for execution.
+    cmCustomCommandGenerator ccg(*cc, configName, makefile);
+
+    const std::vector<std::string>& outputs = ccg.GetOutputs();
+    const std::vector<std::string>& byproducts = ccg.GetByproducts();
+    std::vector<std::string> mergedOutputs;
+    mergedOutputs.insert(mergedOutputs.end(), outputs.begin(), outputs.end());
+    mergedOutputs.insert(mergedOutputs.end(), byproducts.begin(),
+                         byproducts.end());
+
+    // TODO: Double check that none of the outputs are 'symbolic'
+    // In which case, FASTBuild won't want them treated as
+    // outputs.
+    {
+      cmGeneratorTarget* gt = context.self->GetGeneratorTarget(&target);
+      std::vector<cmSourceFile*> sourceFiles;
+      gt->GetSourceFiles(sourceFiles, configName);
+
+      // Loop through all outputs, and attempt to find it in the
+      // source files.
+      for (size_t index = 0; index < mergedOutputs.size(); ++index) {
+        const std::string& outputName = mergedOutputs[index];
+
+        std::vector<cmSourceFile*>::iterator findResult =
+          std::find_if(sourceFiles.begin(), sourceFiles.end(),
+                       SourceFileNameIs(outputName));
+
+        if (findResult == sourceFiles.end()) {
+          continue;
+        }
+        cmSourceFile* outputSourceFile = *findResult;
+
+        // Check if this file is symbolic
+        if (outputSourceFile->GetPropertyAsBool("SYMBOLIC")) {
+          // We need to remove this file from the list of outputs
+          // Swap with back and pop
+          mergedOutputs[index] = mergedOutputs.back();
+          mergedOutputs.pop_back();
+        }
+      }
+    }
+
+    std::vector<std::string> inputs;
+    std::vector<std::string> orderDependencies;
+
+    // If this exec node always generates outputs,
+    // then we need to make sure we don't define outputs multiple times.
+    // but if the command should always run (i.e. post builds etc)
+    // then we will output a new one.
+    if (!mergedOutputs.empty()) {
+      // Check if this custom command has already been output.
+      // If it has then just drop an alias here to the original
+      CustomCommandAliasMap::iterator findResult =
+        context.customCommandAliases.find(cc);
+      if (findResult != context.customCommandAliases.end() &&
+          !Detection::isConfigDependant(ccg)) {
+        // This command has already been generated.
+        // So just drop an alias.
+        std::vector<std::string> targets;
+        targets.push_back(findResult->second);
+
+        context.fc.WriteCommand("Alias", Quote(targetName));
+        context.fc.WritePushScope();
+        {
+          context.fc.WriteArray("Targets", Wrap(targets));
+        }
+        context.fc.WritePopScope();
+        return;
+      }
+      context.customCommandAliases[cc] = targetName;
+    }
+
+    // Take the dependencies listed and split into targets and files.
+    const std::vector<std::string>& depends = ccg.GetDepends();
+    for (std::vector<std::string>::const_iterator iter = depends.begin();
+         iter != depends.end(); ++iter) {
+      const std::string& dep = *iter;
+
+      bool isTarget = context.self->FindTarget(dep) != NULL;
+      if (isTarget) {
+        orderDependencies.push_back(dep + "-" + configName);
+      } else {
+        inputs.push_back(dep);
+      }
+    }
+
+    std::vector<std::string> cmdLines;
+    if (ccg.GetNumberOfCommands() > 0) {
+      std::string wd = ccg.GetWorkingDirectory();
+      if (wd.empty()) {
+        wd = makefile->GetStartOutputDirectory();
+      }
+
+      std::ostringstream cdCmd;
+#ifdef _WIN32
+      std::string cdStr = "cd /D ";
+#else
+      std::string cdStr = "cd ";
+#endif
+      cdCmd << cdStr << lg->ConvertToOutputFormat(wd, cmLocalGenerator::SHELL);
+      cmdLines.push_back(cdCmd.str());
+    }
+
+    std::string launcher = MakeCustomLauncher(lg, ccg);
+
+    for (unsigned i = 0; i != ccg.GetNumberOfCommands(); ++i) {
+      cmdLines.push_back(
+        launcher +
+        lg->ConvertToOutputFormat(ccg.GetCommand(i), cmLocalGenerator::SHELL));
+
+      std::string& cmd = cmdLines.back();
+      ccg.AppendArguments(i, cmd);
+    }
+
+    std::string cmd = Detection::BuildCommandLine(cmdLines);
+    std::string executable;
+    std::string args;
+    Detection::SplitExecutableAndFlags(cmd, executable, args);
+
+    // Write out an exec command
+    /*
+    Exec(alias); (optional)Alias
+    {
+            .ExecExecutable; Executable to run
+            .ExecInput; Input file to pass to executable
+            .ExecOutput; Output file generated by executable
+            .ExecArguments; (optional)Arguments to pass to executable
+            .ExecWorkingDir; (optional)Working dir to set for executable
+
+            ; Additional options
+            .PreBuildDependencies; (optional)Force targets to be built before
+    this Exec(Rarely needed,
+            ; but useful when Exec relies on externally generated files).
+    }
+    */
+
+    context.fc.WriteCommand("Exec", Quote(targetName));
+    context.fc.WritePushScope();
+    {
+      context.fc.WriteVariable("ExecExecutable", Quote(executable));
+      context.fc.WriteVariable("ExecArguments", Quote(args));
+
+      if (inputs.empty()) {
+        inputs.push_back("dummy-in");
+      }
+      context.fc.WriteArray("ExecInput", Wrap(inputs));
+
+      // Currently fastbuild doesn't support more than 1
+      // output for a custom command (soon to change hopefully).
+      assert(mergedOutputs.size() <= 1);
+
+      if (mergedOutputs.empty()) {
+        context.fc.WriteVariable("ExecUseStdOutAsOutput", "true");
+
+        std::string outputDir =
+          target.GetMakefile()->GetStartOutputDirectory();
+        mergedOutputs.push_back(outputDir + "/dummy-out-" + targetName +
+                                ".txt");
+      }
+      context.fc.WriteVariable("ExecOutput", Quote(Join(mergedOutputs, ";")));
+    }
+    context.fc.WritePopScope();
+  }
+
+  static void WriteCustomBuildSteps(
+    GenerationContext& context, cmLocalFastbuildGenerator* lg,
+    cmTarget& target, const std::vector<cmCustomCommand>& commands,
+    const std::string& buildStep, const std::vector<std::string>& orderDeps)
+  {
+    if (commands.empty()) {
+      return;
+    }
+
+    const std::string& targetName = target.GetName();
+
+    // Now output the commands
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string configName = *iter;
+
+      context.fc.WriteVariable("buildStep_" + buildStep + "_" + configName,
+                               "");
+      context.fc.WritePushScopeStruct();
+
+      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+
+      context.fc.WriteArray("PreBuildDependencies",
+                            Wrap(orderDeps, "'", "-" + configName + "'"), "+");
+
+      std::string baseName = targetName + "-" + buildStep + "-" + configName;
+      int commandCount = 1;
+      std::vector<std::string> customCommandTargets;
+      for (std::vector<cmCustomCommand>::const_iterator ccIter =
+             commands.begin();
+           ccIter != commands.end(); ++ccIter) {
+        const cmCustomCommand& cc = *ccIter;
+
+        std::stringstream customCommandTargetName;
+        customCommandTargetName << baseName << (commandCount++);
+        customCommandTargets.push_back(customCommandTargetName.str());
+
+        WriteCustomCommand(context, &cc, lg, target, configName,
+                           customCommandTargetName.str());
+      }
+
+      // Write an alias for this object group to group them all together
+      context.fc.WriteCommand("Alias", Quote(baseName));
+      context.fc.WritePushScope();
+      context.fc.WriteArray("Targets", Wrap(customCommandTargets, "'", "'"));
+      context.fc.WritePopScope();
+
+      context.fc.WritePopScope();
+    }
+  }
+
+  static bool WriteCustomBuildRules(GenerationContext& context,
+                                    cmLocalFastbuildGenerator* lg,
+                                    cmGeneratorTarget* gt, cmTarget& target)
+  {
+    bool hasCustomCommands = false;
+    const std::string& targetName = target.GetName();
+
+    // Iterating over all configurations
+    const char* customCommandGroupNamePrefix = "ObjectGroup_cmCustomCommands_";
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string configName = *iter;
+
+      context.fc.WriteVariable("CustomCommands_" + configName, "");
+      context.fc.WritePushScopeStruct();
+
+      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+
+      // Figure out the list of custom build rules in use by this target
+      // get a list of source files
+      std::vector<cmSourceFile const*> customCommands;
+      gt->GetCustomCommands(customCommands, configName);
+
+      if (!customCommands.empty()) {
+        // Presort the commands to adjust for dependencies
+        // In a number of cases, the commands inputs will be the outputs
+        // from another command. Need to sort the commands to output them in
+        // order.
+        Detection::DependencySorter::CustomCommandHelper ccHelper = {
+          context.self, lg, configName
+        };
+        Detection::DependencySorter::Sort(ccHelper, customCommands);
+
+        std::vector<std::string> customCommandTargets;
+
+        // Write the custom command build rules for each configuration
+        int commandCount = 1;
+        std::string customCommandNameBase =
+          targetName + "-CustomCommand-" + configName + "-";
+        for (std::vector<cmSourceFile const*>::iterator ccIter =
+               customCommands.begin();
+             ccIter != customCommands.end(); ++ccIter) {
+          const cmSourceFile* sourceFile = *ccIter;
+
+          std::stringstream customCommandTargetName;
+          customCommandTargetName << customCommandNameBase << (commandCount++);
+          customCommandTargetName
+            << "-"
+            << cmSystemTools::GetFilenameName(sourceFile->GetFullPath());
+          ;
+          customCommandTargets.push_back(customCommandTargetName.str());
+
+          WriteCustomCommand(context, sourceFile->GetCustomCommand(), lg,
+                             target, configName,
+                             customCommandTargetName.str());
+        }
+
+        std::string customCommandGroupName =
+          targetName + "-CustomCommands-" + configName;
+
+        // Write an alias for this object group to group them all together
+        context.fc.WriteCommand("Alias", Quote(customCommandGroupName));
+        context.fc.WritePushScope();
+        context.fc.WriteArray("Targets", Wrap(customCommandTargets, "'", "'"));
+        context.fc.WritePopScope();
+
+        // Now make everything use this as prebuilt dependencies
+        std::vector<std::string> tmp;
+        tmp.push_back(customCommandGroupName);
+        context.fc.WriteArray("PreBuildDependencies", Wrap(tmp), "+");
+
+        hasCustomCommands = true;
+      }
+
+      context.fc.WritePopScope();
+    }
+
+    return hasCustomCommands;
+  }
+
+  static void WriteTargetDefinition(GenerationContext& context,
+                                    cmLocalFastbuildGenerator* lg,
+                                    cmTarget& target)
+  {
+    // Detection of the link command as follows:
+    std::string linkCommand = "Library";
+    switch (target.GetType()) {
+      case cmTarget::INTERFACE_LIBRARY:
+        // We don't write out interface libraries.
+        return;
+      case cmTarget::EXECUTABLE: {
+        linkCommand = "Executable";
+        break;
+      }
+      case cmTarget::SHARED_LIBRARY: {
+        linkCommand = "DLL";
+        break;
+      }
+      case cmTarget::STATIC_LIBRARY:
+      case cmTarget::MODULE_LIBRARY:
+      case cmTarget::OBJECT_LIBRARY: {
+        // No changes required
+        break;
+      }
+      case cmTarget::UTILITY:
+      case cmTarget::GLOBAL_TARGET: {
+        // No link command used
+        linkCommand = "NoLinkCommand";
+        break;
+      }
+      case cmTarget::UNKNOWN_LIBRARY: {
+        // Ignoring this target generation...
+        return;
+      }
+    }
+
+    const std::string& targetName = target.GetName();
+    cmGeneratorTarget* gt = context.self->GetGeneratorTarget(&target);
+
+    context.fc.WriteComment("Target definition: " + targetName);
+    context.fc.WritePushScope();
+
+    std::vector<std::string> dependencies;
+    Detection::DetectTargetCompileDependencies(context.self, target,
+                                               dependencies);
+
+    // Output the prebuild/Prelink commands
+    WriteCustomBuildSteps(context, lg, target, target.GetPreBuildCommands(),
+                          "PreBuild", dependencies);
+    WriteCustomBuildSteps(context, lg, target, target.GetPreLinkCommands(),
+                          "PreLink", dependencies);
+
+    // Iterate over each configuration
+    // This time to define linker settings for each config
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string configName = *iter;
+
+      context.fc.WriteVariable("BaseConfig_" + configName, "");
+      context.fc.WritePushScopeStruct();
+
+      context.fc.WriteCommand("Using", ".ConfigBase");
+
+      context.fc.WriteVariable("ConfigName", Quote(configName));
+
+      context.fc.WriteBlankLine();
+      context.fc.WriteComment("General output details:");
+      // Write out the output paths for the outcome of this target
+      {
+        Detection::FastbuildTargetNames targetNames;
+        Detection::DetectOutput(targetNames, lg, target, configName);
+
+        context.fc.WriteVariable("TargetNameOut",
+                                 Quote(targetNames.targetNameOut));
+        context.fc.WriteVariable("TargetNameImport",
+                                 Quote(targetNames.targetNameImport));
+        context.fc.WriteVariable("TargetNamePDB",
+                                 Quote(targetNames.targetNamePDB));
+        context.fc.WriteVariable("TargetNameSO",
+                                 Quote(targetNames.targetNameSO));
+        context.fc.WriteVariable("TargetNameReal",
+                                 Quote(targetNames.targetNameReal));
+
+        // TODO: Remove this if these variables aren't used...
+        // They've been added for testing
+        context.fc.WriteVariable("TargetOutput",
+                                 Quote(targetNames.targetOutput));
+        context.fc.WriteVariable("TargetOutputImplib",
+                                 Quote(targetNames.targetOutputImplib));
+        context.fc.WriteVariable("TargetOutputReal",
+                                 Quote(targetNames.targetOutputReal));
+        context.fc.WriteVariable("TargetOutDir",
+                                 Quote(targetNames.targetOutputDir));
+
+        if (target.GetType() != cmTarget::OBJECT_LIBRARY) {
+          // on Windows the output dir is already needed at compile time
+          // ensure the directory exists (OutDir test)
+          EnsureDirectoryExists(targetNames.targetOutputDir, context);
+        }
+      }
+
+      // Write the dependency list in here too
+      // So all dependant libraries are built before this one is
+      // This is incase this library depends on code generated from previous
+      // ones
+      {
+        context.fc.WriteArray("PreBuildDependencies",
+                              Wrap(dependencies, "'", "-" + configName + "'"));
+      }
+
+      // Add to the list of prebuild deps
+      // The prelink and prebuild commands
+      {
+        std::vector<std::string> preBuildSteps;
+        if (!target.GetPreBuildCommands().empty()) {
+          preBuildSteps.push_back("PreBuild");
+        }
+        if (!target.GetPreLinkCommands().empty()) {
+          preBuildSteps.push_back("PreLink");
+        }
+
+        if (!preBuildSteps.empty()) {
+          context.fc.WriteArray("PreBuildDependencies",
+                                Wrap(preBuildSteps, "'" + targetName + "-",
+                                     "-" + configName + "'"),
+                                "+");
+        }
+      }
+
+      context.fc.WritePopScope();
+    }
+
+    // Write the custom build rules
+    bool hasCustomBuildRules = WriteCustomBuildRules(context, lg, gt, target);
+
+    // Figure out the list of languages in use by this target
+    std::vector<std::string> linkableDeps;
+    std::vector<std::string> orderDeps;
+    std::set<std::string> languages;
+    Detection::DetectLanguages(languages, context.self, target);
+
+    // Write the object list definitions for each language
+    // stored in this target
+    for (std::set<std::string>::iterator langIter = languages.begin();
+         langIter != languages.end(); ++langIter) {
+      const std::string& objectGroupLanguage = *langIter;
+      std::string ruleObjectGroupName = "ObjectGroup_" + objectGroupLanguage;
+      linkableDeps.push_back(ruleObjectGroupName);
+
+      context.fc.WriteVariable(ruleObjectGroupName, "");
+      context.fc.WritePushScopeStruct();
+
+      // Iterating over all configurations
+      for (std::vector<std::string>::iterator iter =
+             context.self->Configurations.begin();
+           iter != context.self->Configurations.end(); ++iter) {
+        std::string configName = *iter;
+        context.fc.WriteVariable("ObjectConfig_" + configName, "");
+        context.fc.WritePushScopeStruct();
+
+        context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+        context.fc.WriteCommand("Using", ".CustomCommands_" + configName);
+
+        context.fc.WriteBlankLine();
+        context.fc.WriteComment("Compiler options:");
+        {
+          // Tie together the variables
+          std::string targetCompileOutDirectory =
+            Detection::DetectTargetCompileOutputDir(lg, target, configName);
+          context.fc.WriteVariable("CompilerOutputPath",
+                                   Quote(targetCompileOutDirectory));
+
+          std::string compileObjectCmd =
+            Detection::DetectCompileRule(lg, target, objectGroupLanguage);
+          // context.fc.WriteVariable("CompilerRuleCmd", Quote(
+          // compileObjectCmd ));
+        }
+
+        // Compiler options
+        std::string baseCompileFlags;
+        {
+          // Remove the command from the front and leave the flags behind
+          std::string compileCmd;
+          Detection::DetectBaseCompileCommand(compileCmd, lg, target,
+                                              objectGroupLanguage);
+
+          std::string executable;
+          Detection::SplitExecutableAndFlags(compileCmd, executable,
+                                             baseCompileFlags);
+
+          context.fc.WriteVariable("CompilerCmdBaseFlags",
+                                   Quote(baseCompileFlags));
+
+          std::string compilerName = ".Compiler_" + objectGroupLanguage;
+          context.fc.WriteVariable("Compiler", compilerName);
+        }
+
+        struct CompileCommand
+        {
+          std::string defines;
+          std::string flags;
+          std::vector<std::string> sourceFiles;
+        };
+        std::map<std::string, CompileCommand> commandPermutations;
+
+        // Source files
+        context.fc.WriteBlankLine();
+        context.fc.WriteComment("Source files:");
+        {
+          // get a list of source files
+          std::vector<cmSourceFile const*> objectSources;
+          gt->GetObjectSources(objectSources, configName);
+
+          std::vector<cmSourceFile const*> filteredObjectSources;
+          Detection::FilterSourceFiles(filteredObjectSources, objectSources,
+                                       objectGroupLanguage);
+
+          // Figure out the compilation commands for all
+          // the translation units in the compilation.
+          // Detect if one of them is a PreCompiledHeader
+          // and extract it to be used in a precompiled header
+          // generation step.
+          for (std::vector<cmSourceFile const*>::iterator sourceIter =
+                 filteredObjectSources.begin();
+               sourceIter != filteredObjectSources.end(); ++sourceIter) {
+            cmSourceFile const* srcFile = *sourceIter;
+            std::string sourceFile = srcFile->GetFullPath();
+
+            // Detect flags and defines
+            std::string compilerFlags;
+            Detection::DetectCompilerFlags(compilerFlags, lg, gt, target,
+                                           srcFile, objectGroupLanguage,
+                                           configName);
+            std::string compileDefines = Detection::ComputeDefines(
+              lg, target, srcFile, configName, objectGroupLanguage);
+
+            std::string configKey = compilerFlags + "{|}" + compileDefines;
+            CompileCommand& command = commandPermutations[configKey];
+            command.sourceFiles.push_back(sourceFile);
+            command.flags = compilerFlags;
+            command.defines = compileDefines;
+          }
+        }
+
+        // Iterate over all subObjectGroups
+        std::string objectGroupRuleName =
+          targetName + "-" + ruleObjectGroupName + "-" + configName;
+        std::vector<std::string> configObjectGroups;
+        int groupNameCount = 1;
+        for (std::map<std::string, CompileCommand>::iterator groupIter =
+               commandPermutations.begin();
+             groupIter != commandPermutations.end(); ++groupIter) {
+          const CompileCommand& command = groupIter->second;
+          std::stringstream ruleName;
+          ruleName << objectGroupRuleName << "-" << (groupNameCount++);
+          configObjectGroups.push_back(ruleName.str());
+
+          context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
+          context.fc.WritePushScope();
+
+          context.fc.WriteArray("CompilerInputFiles",
+                                Wrap(command.sourceFiles, "'", "'"));
+
+          // Unity source files:
+          context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
+
+          context.fc.WriteVariable("CompileDefineFlags",
+                                   Quote(command.defines));
+          context.fc.WriteVariable("CompileFlags", Quote(command.flags));
+          context.fc.WriteVariable(
+            "CompilerOptions",
+            Quote(
+              "$CompileFlags$ $CompileDefineFlags$ $CompilerCmdBaseFlags$"));
+
+          /*
+          if (Detection::DetectPrecompiledHeader(command.flags + " " +
+                  baseCompileFlags + " " + command.defines,
+                  preCompiledHeaderInput,
+                  preCompiledHeaderOutput,
+                  preCompiledHeaderOptions)
+          */
+          context.fc.WritePopScope();
+        }
+
+        // Write an alias for this object group to group them all together
+        context.fc.WriteCommand("Alias", Quote(objectGroupRuleName));
+        context.fc.WritePushScope();
+        context.fc.WriteArray("Targets", Wrap(configObjectGroups, "'", "'"));
+        context.fc.WritePopScope();
+
+        context.fc.WritePopScope();
+      }
+      context.fc.WritePopScope();
+    }
+
+    // Object libraries do not have linker stages
+    // nor utilities
+    bool hasLinkerStage = target.GetType() != cmTarget::OBJECT_LIBRARY &&
+      target.GetType() != cmTarget::UTILITY &&
+      target.GetType() != cmTarget::GLOBAL_TARGET;
+
+    // Iterate over each configuration
+    // This time to define linker settings for each config
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string configName = *iter;
+
+      std::string linkRuleName = targetName + "-link-" + configName;
+
+      if (hasLinkerStage) {
+
+        context.fc.WriteVariable("LinkerConfig_" + configName, "");
+        context.fc.WritePushScopeStruct();
+
+        context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+
+        context.fc.WriteBlankLine();
+        context.fc.WriteComment("Linker options:");
+        // Linker options
+        {
+          std::string linkLibs;
+          std::string targetFlags;
+          std::string linkFlags;
+          std::string frameworkPath;
+          std::string dummyLinkPath;
+
+          lg->GetTargetFlags(linkLibs, targetFlags, linkFlags, frameworkPath,
+                             dummyLinkPath, gt, false);
+
+          std::string linkPath;
+          Detection::DetectLinkerLibPaths(linkPath, lg, target, configName);
+
+          linkPath = frameworkPath + linkPath;
+
+          context.fc.WriteVariable("LinkPath", "'" + linkPath + "'");
+          context.fc.WriteVariable("LinkLibs", "'" + linkLibs + "'");
+          context.fc.WriteVariable("LinkFlags", "'" + linkFlags + "'");
+
+          // Remove the command from the front and leave the flags behind
+          std::string linkCmd;
+          if (!Detection::DetectBaseLinkerCommand(linkCmd, lg, target, gt,
+                                                  configName)) {
+            return;
+          }
+
+          std::string executable;
+          std::string flags;
+          Detection::SplitExecutableAndFlags(linkCmd, executable, flags);
+
+          context.fc.WriteVariable("Linker", Quote(executable));
+          context.fc.WriteVariable("BaseLinkerOptions", Quote(flags));
+
+          context.fc.WriteVariable("LinkerOutput", "'$TargetOutput$'");
+          context.fc.WriteVariable("LinkerOptions",
+                                   "'$BaseLinkerOptions$ $LinkLibs$'");
+
+          context.fc.WriteArray("Libraries",
+                                Wrap(linkableDeps, "'" + targetName + "-",
+                                     "-" + configName + "'"));
+
+          // Now detect the extra dependencies for linking
+          {
+            std::vector<std::string> dependencies;
+            Detection::DetectTargetObjectDependencies(
+              context.self, target, configName, dependencies);
+            Detection::DetectTargetLinkDependencies(context.self, target,
+                                                    configName, dependencies);
+
+            context.fc.WriteArray("Libraries", Wrap(dependencies, "'", "'"),
+                                  "+");
+          }
+
+          context.fc.WriteCommand(linkCommand, Quote(linkRuleName));
+          context.fc.WritePushScope();
+          if (linkCommand == "Library") {
+            context.fc.WriteComment(
+              "Convert the linker options to work with libraries");
+
+            // Push dummy definitions for compilation variables
+            // These variables are required by the Library command
+            context.fc.WriteVariable("Compiler", ".Compiler_dummy");
+            context.fc.WriteVariable("CompilerOptions", "'-c %1 %2'");
+            context.fc.WriteVariable("CompilerOutputPath", "'/dummy/'");
+
+            // These variables are required by the Library command as well
+            // we just need to transfer the values in the linker variables
+            // to these locations
+            context.fc.WriteVariable("Librarian", "'$Linker$'");
+            context.fc.WriteVariable("LibrarianOptions", "'$LinkerOptions$'");
+            context.fc.WriteVariable("LibrarianOutput", "'$LinkerOutput$'");
+
+            context.fc.WriteVariable("LibrarianAdditionalInputs",
+                                     ".Libraries");
+          }
+          context.fc.WritePopScope();
+        }
+        context.fc.WritePopScope();
+      }
+    }
+
+    if (!target.GetPreBuildCommands().empty()) {
+      orderDeps.push_back("PreBuild");
+    }
+    if (!target.GetPreLinkCommands().empty()) {
+      orderDeps.push_back("PreLink");
+    }
+    if (hasCustomBuildRules) {
+      orderDeps.push_back("CustomCommands");
+    }
+    if (hasLinkerStage) {
+      linkableDeps.push_back("link");
+      orderDeps.push_back("link");
+    }
+
+    // Output the postbuild commands
+    WriteCustomBuildSteps(context, lg, target, target.GetPostBuildCommands(),
+                          "PostBuild", Wrap(orderDeps, targetName + "-", ""));
+
+    // Always add the pre/post build steps as
+    // part of the alias.
+    // This way, if there are ONLY build steps, then
+    // things should still work too.
+    if (!target.GetPostBuildCommands().empty()) {
+      orderDeps.push_back("PostBuild");
+    }
+
+    // Output a list of aliases
+    WriteTargetAliases(context, target, linkableDeps, orderDeps);
+
+    context.fc.WritePopScope();
+  }
+
+  static void WriteTargetAliases(GenerationContext& context, cmTarget& target,
+                                 const std::vector<std::string>& linkableDeps,
+                                 const std::vector<std::string>& orderDeps)
+  {
+    const std::string& targetName = target.GetName();
+
+    for (std::vector<std::string>::iterator iter =
+           context.self->Configurations.begin();
+         iter != context.self->Configurations.end(); ++iter) {
+      std::string configName = *iter;
+
+      if (!linkableDeps.empty()) {
+        context.fc.WriteCommand(
+          "Alias", Quote(targetName + "-" + configName + "-products"));
+        context.fc.WritePushScope();
+        context.fc.WriteArray(
+          "Targets",
+          Wrap(linkableDeps, "'" + targetName + "-", "-" + configName + "'"));
+        context.fc.WritePopScope();
+      }
+
+      if (!orderDeps.empty() || !linkableDeps.empty()) {
+        context.fc.WriteCommand("Alias", Quote(targetName + "-" + configName));
+        context.fc.WritePushScope();
+        context.fc.WriteArray(
+          "Targets",
+          Wrap(linkableDeps, "'" + targetName + "-", "-" + configName + "'"));
+        context.fc.WriteArray(
+          "Targets",
+          Wrap(orderDeps, "'" + targetName + "-", "-" + configName + "'"),
+          "+");
+        context.fc.WritePopScope();
+      }
+    }
+  }
+
+  static void WriteTargetUtilityDefinition(GenerationContext& context,
+                                           cmLocalFastbuildGenerator* lg,
+                                           cmTarget& target)
+  {
+    WriteTargetDefinition(context, lg, target);
+  }
+
+  static void WriteTargetDefinitions(GenerationContext& context)
+  {
+    context.fc.WriteSectionHeader("Target Definitions");
+
+    // Now iterate each target in order
+    for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
+         targetIter != context.orderedTargets.end(); ++targetIter) {
+      const cmTarget* constTarget = (*targetIter);
+      if (constTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
+        continue;
+      }
+
+      TargetContextMap::iterator findResult =
+        context.targetContexts.find(constTarget);
+      if (findResult == context.targetContexts.end()) {
+        continue;
+      }
+
+      cmTarget* target = findResult->second.target;
+      cmLocalFastbuildGenerator* lg = findResult->second.lg;
+
+      switch (target->GetType()) {
+        case cmTarget::EXECUTABLE:
+        case cmTarget::SHARED_LIBRARY:
+        case cmTarget::STATIC_LIBRARY:
+        case cmTarget::MODULE_LIBRARY:
+        case cmTarget::OBJECT_LIBRARY:
+          WriteTargetDefinition(context, lg, *target);
+          break;
+        case cmTarget::UTILITY:
+        case cmTarget::GLOBAL_TARGET:
+          WriteTargetUtilityDefinition(context, lg, *target);
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  static void WriteAliases(GenerationContext& context)
+  {
+    context.fc.WriteSectionHeader("Aliases");
+
+    // Write the following aliases:
+    // Per Target
+    // Per Config
+    // All
+
+    typedef std::map<std::string, std::vector<std::string> > TargetListMap;
+    TargetListMap perConfig;
+    TargetListMap perTarget;
+
+    for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
+         targetIter != context.orderedTargets.end(); ++targetIter) {
+      const cmTarget* constTarget = (*targetIter);
+      if (constTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
+        continue;
+      }
+
+      TargetContextMap::iterator findResult =
+        context.targetContexts.find(constTarget);
+      if (findResult == context.targetContexts.end()) {
+        continue;
+      }
+
+      cmTarget* target = findResult->second.target;
+      cmLocalFastbuildGenerator* lg = findResult->second.lg;
+      const std::string& targetName = target->GetName();
+
+      // Define compile flags
+      for (std::vector<std::string>::iterator iter =
+             context.self->Configurations.begin();
+           iter != context.self->Configurations.end(); ++iter) {
+        std::string& configName = *iter;
+        std::string aliasName = targetName + "-" + configName;
+
+        perTarget[targetName].push_back(aliasName);
+
+        if (!target->GetPropertyAsBool("EXCLUDE_FROM_ALL")) {
+          perConfig[configName].push_back(aliasName);
+        }
+      }
+    }
+
+    context.fc.WriteComment("Per config");
+    for (TargetListMap::iterator iter = perConfig.begin();
+         iter != perConfig.end(); ++iter) {
+      const std::string& configName = iter->first;
+      const std::vector<std::string>& targets = iter->second;
+
+      context.fc.WriteCommand("Alias", "'" + configName + "'");
+      context.fc.WritePushScope();
+      context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
+      context.fc.WritePopScope();
+    }
+
+    context.fc.WriteComment("Per targets");
+    for (TargetListMap::iterator iter = perTarget.begin();
+         iter != perTarget.end(); ++iter) {
+      const std::string& targetName = iter->first;
+      const std::vector<std::string>& targets = iter->second;
+
+      context.fc.WriteCommand("Alias", "'" + targetName + "'");
+      context.fc.WritePushScope();
+      context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
+      context.fc.WritePopScope();
+    }
+
+    context.fc.WriteComment("All");
+    context.fc.WriteCommand("Alias", "'All'");
+    context.fc.WritePushScope();
+    context.fc.WriteArray("Targets",
+                          Wrap(context.self->Configurations, "'", "'"));
+    context.fc.WritePopScope();
+  }
+};
+
+//----------------------------------------------------------------------------
+cmGlobalGeneratorFactory* cmGlobalFastbuildGenerator::NewFactory()
+{
+  return new Factory();
+}
+
+//----------------------------------------------------------------------------
+cmGlobalFastbuildGenerator::cmGlobalFastbuildGenerator()
+{
+  this->FindMakeProgramFile = "CMakeFastbuildFindMake.cmake";
+}
+
+//----------------------------------------------------------------------------
+cmGlobalFastbuildGenerator::~cmGlobalFastbuildGenerator()
+{
+}
+
+//----------------------------------------------------------------------------
+std::string cmGlobalFastbuildGenerator::GetName() const
+{
+  return fastbuildGeneratorName;
+}
+
+//----------------------------------------------------------------------------
+cmLocalGenerator* cmGlobalFastbuildGenerator::CreateLocalGenerator()
+{
+  cmLocalGenerator* lg = new cmLocalFastbuildGenerator();
+  lg->SetGlobalGenerator(this);
+  return lg;
+}
+
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::EnableLanguage(
+  std::vector<std::string> const& lang, cmMakefile* mf, bool optional)
+{
+  // Create list of configurations requested by user's cache, if any.
+  this->cmGlobalGenerator::EnableLanguage(lang, mf, optional);
+  Detail::Detection::DetectConfigurations(this, mf, this->Configurations);
+}
+
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::Generate()
+{
+  // Execute the standard generate process
+  cmGlobalGenerator::Generate();
+
+  Detail::Generation::GenerateRootBFF(this);
+}
+
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::GenerateBuildCommand(
+  std::vector<std::string>& makeCommand, const std::string& makeProgram,
+  const std::string& projectName, const std::string& projectDir,
+  const std::string& targetName, const std::string& config, bool fast,
+  bool verbose, std::vector<std::string> const& makeOptions)
+{
+  // A build command for fastbuild looks like this:
+  // fbuild.exe [make-options] [-config projectName.bff] <target>-<config>
+
+  // Setup make options
+  std::vector<std::string> makeOptionsSelected;
+
+  // Select the caller- or user-preferred make program
+  std::string makeProgramSelected = this->SelectMakeProgram(makeProgram);
+
+  // Select the target
+  std::string targetSelected = targetName;
+  // Note an empty target is a valid target (defaults to ALL anyway)
+  if (targetSelected == "clean") {
+    makeOptionsSelected.push_back("-clean");
+    targetSelected = "";
+  }
+
+  // Select the config
+  std::string configSelected = config;
+  if (configSelected.empty()) {
+    configSelected = "Debug";
+  }
+
+  // Select fastbuild target
+  if (targetSelected.empty()) {
+    targetSelected = configSelected;
+  } else {
+    targetSelected += "-" + configSelected;
+  }
+
+  // Build the command
+  makeCommand.push_back(makeProgramSelected);
+
+  // Push in the make options
+  makeCommand.insert(makeCommand.end(), makeOptionsSelected.begin(),
+                     makeOptionsSelected.end());
+
+  /*
+  makeCommand.push_back("-config");
+  makeCommand.push_back(projectName + ".bff");
+  */
+
+  makeCommand.push_back("-showcmds");
+  makeCommand.push_back("-ide");
+
+  // Add the target-config to the command
+  if (!targetSelected.empty()) {
+    makeCommand.push_back(targetSelected);
+  }
+}
+
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::AppendDirectoryForConfig(
+  const std::string& prefix, const std::string& config,
+  const std::string& suffix, std::string& dir)
+{
+  if (!config.empty()) {
+    dir += prefix;
+    dir += config;
+    dir += suffix;
+  }
+}
+
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::ComputeTargetObjectDirectory(
+  cmGeneratorTarget* gt) const
+{
+  cmTarget* target = gt->Target;
+
+  // Compute full path to object file directory for this target.
+  std::string dir;
+  dir += gt->Makefile->GetCurrentOutputDirectory();
+  dir += "/";
+  dir += gt->LocalGenerator->GetTargetDirectory(*target);
+  dir += "/";
+  gt->ObjectDirectory = dir;
+}
+
+//----------------------------------------------------------------------------
+const char* cmGlobalFastbuildGenerator::GetCMakeCFGIntDir() const
+{
+  return "$ConfigName$";
+}
+
+//----------------------------------------------------------------------------

--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -1,84 +1,80 @@
 
 /*============================================================================
-  CMake - Cross Platform Makefile Generator
-  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+        CMake - Cross Platform Makefile Generator
+        Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
 
-  Distributed under the OSI-approved BSD License (the "License");
-  see accompanying file Copyright.txt for details.
+        Distributed under the OSI-approved BSD License (the "License");
+        see accompanying file Copyright.txt for details.
 
-  This software is distributed WITHOUT ANY WARRANTY; without even the
-  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  See the License for more information.
+        This software is distributed WITHOUT ANY WARRANTY; without even the
+        implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.
+        See the License for more information.
 ============================================================================*/
 /*============================================================================
-  Development progress:
+        Development progress:
 
-  Tasks/Issues:
-   - Execute unit tests against the generator somehow
-   - Fix target aliases being repeated in the output
-   - Fix cmake build using fastbuild (currently appears configuration
+        Tasks/Issues:
+         - Execute unit tests against the generator somehow
+         - Fix target aliases being repeated in the output
+         - Fix cmake build using fastbuild (currently appears configuration
 incorrect)
-   - Running some of the Cmake generation, the pdb files can't be deleted
+         - Running some of the Cmake generation, the pdb files can't be deleted
 (shows up errors)
-   - Depends upon visual studio generator code to sort dependencies
-   - When generating CMAKE from scratch, it sometimes errors with fortran
+         - Depends upon visual studio generator code to sort dependencies
+         - When generating CMAKE from scratch, it sometimes errors with fortran
 complaints and fails generation?
          a re-run will succeed.
-   - Linker for msvc uses the cmake command to callback. Don't think this is an
-issue since
+         - Linker for msvc uses the cmake command to callback. Don't think this
+is an issue since
          I think compilation is the part that gets distributed anyway.
          But it might mean that the cache has trouble calculating deps for
 obj->lib/exe.
          Not sure if Fastbuild supports that anyway yet
-   - Need to sort custom build commands by their outputs
+         - Need to sort custom build commands by their outputs
 
-  Fastbuild bugs:
-   - Defining prebuild dependencies that don't exist, causes the error output
-when that
+        Fastbuild bugs:
+         - Defining prebuild dependencies that don't exist, causes the error
+output when that
          target is actually defined. Rather than originally complaining that
 the target
          doesn't exist where the reference is attempted.
-   - Parsing strings with double $$ doesn't generate a nice error
-   - Undocumented that you can escape a $ with ^$
-   - ExecInputs is invalid empty
-   - Would be great if you could define dummy targets (maybe blank aliases?)
-   - Exec nodes need to not worry about dummy output files not being created
-   - Would be nice if nodes didn't need to be completely in order. But then
-cycles would be possible
-   - Implib directory is not created for exeNodes (DLLs work now though)
+         - Parsing strings with double $$ doesn't generate a nice error
+         - Undocumented that you can escape a $ with ^$
+         - ExecInputs is invalid empty
+         - Would be great if you could define dummy targets (maybe blank
+aliases?)
+         - Exec nodes need to not worry about dummy output files not being
+created
+         - Would be nice if nodes didn't need to be completely in order. But
+then cycles would be possible
+         - Implib directory is not created for exeNodes (DLLs work now though)
 
-  Limitations:
-   - Only tested/working with MSVC
+        Limitations:
+         - Only tested/working with MSVC
 
-  Notes:
-   - Understanding Custom Build Steps and Build Events
-     https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
+        Notes:
+         - Understanding Custom Build Steps and Build Events
+                 https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
          very useful documentation detailing the order of execution
          of standard MSVC events. This is useful to determine correct
          behaviour of fastbuild generator (view a project generated to MSVC,
          then apply the same rules/assumptions back into fastbuild).
          i.e. Custom rules are always executed first.
 
-  Current list of unit tests failing:
+        Current list of unit tests failing:
 
-        89% tests passed, 41 tests failed out of 368
-        Total Test time (real) = 8386.39 sec
+        91% tests passed, 32 tests failed out of 371
+        Total Test time (real) = 1479.86 sec
 
-        The following tests FAILED:
-        58 - SourceGroups (Failed)
-        59 - Preprocess (Failed)
-        60 - ExportImport (Failed)
-        68 - StagingPrefix (Failed)
-        70 - ConfigSources (Failed)
-        78 - Module.ExternalData (Timeout)
-        79 - Module.GenerateExportHeader (Failed)
-        100 - SubProject (Failed)
+The following tests FAILED:
+         59 - Preprocess (Failed)
+         60 - ExportImport (Failed)
+         68 - StagingPrefix (Failed)
+         70 - ConfigSources (Failed)
+         79 - Module.GenerateExportHeader (Failed)
         101 - SubProject-Stage2 (Failed)
-        107 - GeneratorExpression (Failed)
-        108 - CustomCommand (Timeout)
-        109 - CustomCommandByproducts (Timeout)
-        112 - OutOfSource (Failed)
-        113 - BuildDepends (Timeout)
+        113 - BuildDepends (Failed)
         114 - SimpleInstall (Failed)
         115 - SimpleInstall-Stage2 (Failed)
         127 - complex (Failed)
@@ -88,24 +84,20 @@ cycles would be possible
         133 - ExternalProjectUpdateSetup (Failed)
         134 - ExternalProjectUpdate (Failed)
         151 - Plugin (Failed)
-        154 - SubDir (Failed)
-        156 - PDBDirectoryAndName (Failed)
         157 - PrecompiledHeader (Failed)
-        158 - ModuleDefinition (Failed)
-        182 - CTestConfig.Script.Debug (Failed)
-        183 - CTestConfig.Dashboard.Debug (Failed)
-        184 - CTestConfig.Script.MinSizeRel (Failed)
-        185 - CTestConfig.Dashboard.MinSizeRel (Failed)
-        186 - CTestConfig.Script.Release (Failed)
-        187 - CTestConfig.Dashboard.Release (Failed)
-        188 - CTestConfig.Script.RelWithDebInfo (Failed)
-        189 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
-        195 - CMakeCommands.target_compile_options (Failed)
-        221 - Java (Failed)
-        223 - IncludeDirectories (Failed)
-        237 - CMakeOnly.CheckStructHasMember (Failed)
-        274 - RunCMake.Configure (Failed)
-        330 - RunCMake.File_Generate (Failed)
+        184 - CTestConfig.Script.Debug (Failed)
+        185 - CTestConfig.Dashboard.Debug (Failed)
+        186 - CTestConfig.Script.MinSizeRel (Failed)
+        187 - CTestConfig.Dashboard.MinSizeRel (Failed)
+        188 - CTestConfig.Script.Release (Failed)
+        189 - CTestConfig.Dashboard.Release (Failed)
+        190 - CTestConfig.Script.RelWithDebInfo (Failed)
+        191 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
+        197 - CMakeCommands.target_compile_options (Failed)
+        238 - CMakeOnly.CheckStructHasMember (Failed)
+        275 - RunCMake.Configure (Failed)
+        331 - RunCMake.File_Generate (Failed)
+        371 - CMake.CheckSourceTree (Failed)
 ============================================================================*/
 #include "cmGlobalFastbuildGenerator.h"
 
@@ -256,10 +248,35 @@ private:
 class cmGlobalFastbuildGenerator::Detail::Detection
 {
 public:
+  static std::string GetLastFolderName(const std::string& string)
+  {
+    return string.substr(string.rfind('/'));
+  }
+
+  static bool IsExcludedFromAll(cmTarget* target)
+  {
+    bool excluded = target->GetPropertyAsBool("EXCLUDE_FROM_ALL");
+    cmLocalGenerator* lg = target->GetMakefile()->GetLocalGenerator();
+    while (lg->GetParent() != 0 && !excluded) {
+      excluded = lg->GetMakefile()->GetPropertyAsBool("EXCLUDE_FROM_ALL");
+      lg = lg->GetParent();
+    }
+
+    return excluded;
+  }
+
   static void UnescapeFastbuildVariables(std::string& string)
   {
     // Unescape the Fastbuild configName symbol with $
     cmSystemTools::ReplaceString(string, "$$ConfigName$$", "$ConfigName$");
+    cmSystemTools::ReplaceString(string, "^$ConfigName^$", "$ConfigName$");
+  }
+
+  static void ResolveFastbuildVariables(std::string& string,
+                                        const std::string& configName)
+  {
+    // Replace Fastbuild configName with the config name
+    cmSystemTools::ReplaceString(string, "$ConfigName$", configName);
   }
 
   static std::string BuildCommandLine(const std::vector<std::string>& cmdLines)
@@ -332,6 +349,8 @@ public:
     if (configurations.size() == 0) {
       configurations.push_back("Debug");
       configurations.push_back("Release");
+      configurations.push_back("MinSizeRel");
+      configurations.push_back("RelWithDebInfo");
     }
 
     // Reset the entry to have a semi-colon separated list.
@@ -1147,11 +1166,11 @@ public:
           "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\msobj120.dll",
           "$CompilerRoot$\\mspdb120.dll", "$CompilerRoot$\\mspdbcore.dll",
           "$CompilerRoot$\\mspft120.dll", "$CompilerRoot$\\1033\\clui.dll",
-          "$CompilerRoot$\\..\\..\\VC\\redist\\x86\\Microsoft.VC120."
-          "CRT\\msvcp120.dll",
-          "$CompilerRoot$\\..\\..\\VC\\redist\\x86\\Microsoft.VC120."
-          "CRT\\msvcr120.dll",
-          "$CompilerRoot$\\..\\..\\VC\\redist\\x86\\Microsoft.VC120."
+          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcp120."
+          "dll",
+          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcr120."
+          "dll",
+          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120."
           "CRT\\vccorlib120.dll"
         };
         extraFiles.insert(extraFiles.end(), &vs2013_extraFiles[0],
@@ -1163,14 +1182,14 @@ public:
           "$CompilerRoot$\\c1xx.dll", "$CompilerRoot$\\c1xxast.dll",
           "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\mspft110.dll",
           "$CompilerRoot$\\1033\\clui.dll", "$CompilerRoot$\\..\\.."
-                                            "\\VC\\redist\\x86\\Microsoft."
-                                            "VC110.CRT\\msvcp110.dll",
-          "$CompilerRoot$\\..\\..\\VC\\redist\\x86\\Microsoft.VC110."
-          "CRT\\msvcr110.dll",
-          "$CompilerRoot$\\..\\..\\VC\\redist\\x86\\Microsoft.VC110."
+                                            "\\redist\\x86\\Microsoft.VC110."
+                                            "CRT\\msvcp110.dll",
+          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110.CRT\\msvcr110."
+          "dll",
+          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110."
           "CRT\\vccorlib110.dll",
-          "$CompilerRoot$\\..\\..\\Common7\\IDE\\mspdb110.dll",
-          "$CompilerRoot$\\..\\..\\Common7\\IDE\\mspdbcore.dll"
+          "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdb110.dll",
+          "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdbcore.dll"
         };
         extraFiles.insert(extraFiles.end(), &vs2012_extraFiles[0],
                           &vs2012_extraFiles[12]);
@@ -1246,7 +1265,9 @@ public:
   static std::string Quote(const std::string& str,
                            const std::string& quotation = "'")
   {
-    return quotation + str + quotation;
+    std::string result = str;
+    cmSystemTools::ReplaceString(result, quotation, "^" + quotation);
+    return quotation + result + quotation;
   }
 
   static std::string Join(const std::vector<std::string>& elems,
@@ -1564,55 +1585,6 @@ public:
       "all_configs", Wrap(context.self->GetConfigurations(), ".config_", ""));
   }
 
-  static std::string MakeCustomLauncher(cmLocalFastbuildGenerator* lg,
-                                        cmCustomCommandGenerator const& ccg)
-  {
-    const char* property = "RULE_LAUNCH_CUSTOM";
-    const char* property_value = lg->GetMakefile()->GetProperty(property);
-
-    if (!property_value || !*property_value) {
-      return std::string();
-    }
-
-    // Expand rules in the empty string.  It may insert the launcher and
-    // perform replacements.
-    cmLocalGenerator::RuleVariables vars;
-    vars.RuleLauncher = property;
-    std::string output;
-    const std::vector<std::string>& outputs = ccg.GetOutputs();
-    if (!outputs.empty()) {
-      cmLocalGenerator::RelativeRoot relative_root =
-        ccg.GetWorkingDirectory().empty() ? cmLocalGenerator::START_OUTPUT
-                                          : cmLocalGenerator::NONE;
-
-      output = lg->Convert(outputs[0], relative_root, cmLocalGenerator::SHELL);
-    }
-    vars.Output = output.c_str();
-
-    std::string launcher;
-    lg->ExpandRuleVariables(launcher, vars);
-    if (!launcher.empty()) {
-      launcher += " ";
-    }
-
-    return launcher;
-  }
-
-  struct SourceFileNameIs
-  {
-    SourceFileNameIs(const std::string& name)
-      : m_name(name)
-    {
-    }
-
-    std::string m_name;
-
-    bool operator()(const cmSourceFile* sf) const
-    {
-      return sf->GetFullPath() == m_name;
-    }
-  };
-
   static void WriteCustomCommand(GenerationContext& context,
                                  const cmCustomCommand* cc,
                                  cmLocalFastbuildGenerator* lg,
@@ -1636,26 +1608,15 @@ public:
     // In which case, FASTBuild won't want them treated as
     // outputs.
     {
-      cmGeneratorTarget* gt = context.self->GetGeneratorTarget(&target);
-      std::vector<cmSourceFile*> sourceFiles;
-      gt->GetSourceFiles(sourceFiles, configName);
-
       // Loop through all outputs, and attempt to find it in the
       // source files.
       for (size_t index = 0; index < mergedOutputs.size(); ++index) {
         const std::string& outputName = mergedOutputs[index];
 
-        std::vector<cmSourceFile*>::iterator findResult =
-          std::find_if(sourceFiles.begin(), sourceFiles.end(),
-                       SourceFileNameIs(outputName));
-
-        if (findResult == sourceFiles.end()) {
-          continue;
-        }
-        cmSourceFile* outputSourceFile = *findResult;
-
+        cmSourceFile* outputSourceFile = makefile->GetSource(outputName);
         // Check if this file is symbolic
-        if (outputSourceFile->GetPropertyAsBool("SYMBOLIC")) {
+        if (outputSourceFile &&
+            outputSourceFile->GetPropertyAsBool("SYMBOLIC")) {
           // We need to remove this file from the list of outputs
           // Swap with back and pop
           mergedOutputs[index] = mergedOutputs.back();
@@ -1708,40 +1669,32 @@ public:
       }
     }
 
-    std::vector<std::string> cmdLines;
-    if (ccg.GetNumberOfCommands() > 0) {
-      std::string wd = ccg.GetWorkingDirectory();
-      if (wd.empty()) {
-        wd = makefile->GetStartOutputDirectory();
-      }
-
-      std::ostringstream cdCmd;
 #ifdef _WIN32
-      std::string cdStr = "cd /D ";
+    const std::string shellExt = ".bat";
 #else
-      std::string cdStr = "cd ";
+    const std::string shellExt = ".sh";
 #endif
-      cdCmd << cdStr << lg->ConvertToOutputFormat(wd, cmLocalGenerator::SHELL);
-      cmdLines.push_back(cdCmd.str());
-    }
 
-    std::string launcher = MakeCustomLauncher(lg, ccg);
+    std::string scriptFileName(ccg.GetWorkingDirectory() + targetName +
+                               ".bat");
+    cmsys::ofstream scriptFile(scriptFileName.c_str());
 
     for (unsigned i = 0; i != ccg.GetNumberOfCommands(); ++i) {
-      cmdLines.push_back(
-        launcher +
-        lg->ConvertToOutputFormat(ccg.GetCommand(i), cmLocalGenerator::SHELL));
+      std::string args;
+      ccg.AppendArguments(i, args);
+      cmSystemTools::ReplaceString(args, "$$", "$");
+#ifdef _WIN32
+      // in windows batch, '%' is a special character that needs to be doubled
+      // to be escaped
+      cmSystemTools::ReplaceString(args, "%", "%%");
+#endif
+      Detection::ResolveFastbuildVariables(args, configName);
 
-      std::string& cmd = cmdLines.back();
-      ccg.AppendArguments(i, cmd);
+      std::string command(ccg.GetCommand(i));
+      Detection::ResolveFastbuildVariables(command, configName);
+
+      scriptFile << command << args << std::endl;
     }
-
-    std::string cmd = Detection::BuildCommandLine(cmdLines);
-    Detection::UnescapeFastbuildVariables(cmd);
-
-    std::string executable;
-    std::string args;
-    Detection::SplitExecutableAndFlags(cmd, executable, args);
 
     // Write out an exec command
     /*
@@ -1763,17 +1716,21 @@ public:
     context.fc.WriteCommand("Exec", Quote(targetName));
     context.fc.WritePushScope();
     {
-      context.fc.WriteVariable("ExecExecutable", Quote(executable));
-      context.fc.WriteVariable("ExecArguments", Quote(args));
+#ifdef _WIN32
+      context.fc.WriteVariable("ExecExecutable",
+                               Quote(cmSystemTools::FindProgram("cmd.exe")));
+      context.fc.WriteVariable("ExecArguments", Quote("/C " + scriptFileName));
+#else
+      context.fc.WriteVariable("ExecExecutable", Quote(scriptFileName));
+#endif
+      if (!ccg.GetWorkingDirectory().empty())
+        context.fc.WriteVariable("ExecWorkingDir",
+                                 Quote(ccg.GetWorkingDirectory()));
 
       if (inputs.empty()) {
         inputs.push_back("dummy-in");
       }
       context.fc.WriteArray("ExecInput", Wrap(inputs));
-
-      // Currently fastbuild doesn't support more than 1
-      // output for a custom command (soon to change hopefully).
-      assert(mergedOutputs.size() <= 1);
 
       if (mergedOutputs.empty()) {
         context.fc.WriteVariable("ExecUseStdOutAsOutput", "true");
@@ -1783,7 +1740,10 @@ public:
         mergedOutputs.push_back(outputDir + "/dummy-out-" + targetName +
                                 ".txt");
       }
-      context.fc.WriteVariable("ExecOutput", Quote(Join(mergedOutputs, ";")));
+      // Currently fastbuild doesn't support more than 1
+      // output for a custom command (soon to change hopefully).
+      // so only use the first one
+      context.fc.WriteVariable("ExecOutput", Quote(mergedOutputs[0]));
     }
     context.fc.WritePopScope();
   }
@@ -1926,7 +1886,7 @@ public:
   {
     std::string defines;
     std::string flags;
-    std::vector<std::string> sourceFiles;
+    std::map<std::string, std::vector<std::string> > sourceFiles;
   };
 
   static void WriteTargetDefinition(GenerationContext& context,
@@ -1974,12 +1934,6 @@ public:
     std::vector<std::string> dependencies;
     Detection::DetectTargetCompileDependencies(context.self, target,
                                                dependencies);
-
-    // Output the prebuild/Prelink commands
-    WriteCustomBuildSteps(context, lg, target, target.GetPreBuildCommands(),
-                          "PreBuild", dependencies);
-    WriteCustomBuildSteps(context, lg, target, target.GetPreLinkCommands(),
-                          "PreLink", dependencies);
 
     // Iterate over each configuration
     // This time to define linker settings for each config
@@ -2041,6 +1995,27 @@ public:
                               Wrap(dependencies, "'", "-" + configName + "'"));
       }
 
+      context.fc.WritePopScope();
+    }
+
+    // Output the prebuild/Prelink commands
+    WriteCustomBuildSteps(context, lg, target, target.GetPreBuildCommands(),
+                          "PreBuild", dependencies);
+    WriteCustomBuildSteps(context, lg, target, target.GetPreLinkCommands(),
+                          "PreLink", dependencies);
+
+    // Iterate over each configuration
+    // This time to define prebuild and post build targets for each config
+    configIter = context.self->GetConfigurations().begin();
+    configEnd = context.self->GetConfigurations().end();
+    for (; configIter != configEnd; ++configIter) {
+      const std::string& configName = *configIter;
+
+      context.fc.WriteVariable("BaseCompilationConfig_" + configName, "");
+      context.fc.WritePushScopeStruct();
+
+      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+
       // Add to the list of prebuild deps
       // The prelink and prebuild commands
       {
@@ -2090,21 +2065,12 @@ public:
         context.fc.WriteVariable("ObjectConfig_" + configName, "");
         context.fc.WritePushScopeStruct();
 
-        context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
+        context.fc.WriteCommand("Using",
+                                ".BaseCompilationConfig_" + configName);
         context.fc.WriteCommand("Using", ".CustomCommands_" + configName);
 
         context.fc.WriteBlankLine();
         context.fc.WriteComment("Compiler options:");
-        {
-          // Tie together the variables
-          std::string targetCompileOutDirectory =
-            Detection::DetectTargetCompileOutputDir(lg, target, configName);
-          context.fc.WriteVariable("CompilerOutputPath",
-                                   Quote(targetCompileOutDirectory));
-
-          std::string compileObjectCmd =
-            Detection::DetectCompileRule(lg, target, objectGroupLanguage);
-        }
 
         // Compiler options
         std::string baseCompileFlags;
@@ -2164,7 +2130,8 @@ public:
 
             std::string configKey = compilerFlags + "{|}" + compileDefines;
             CompileCommand& command = commandPermutations[configKey];
-            command.sourceFiles.push_back(sourceFile);
+            command.sourceFiles[srcFile->GetLocation().GetDirectory()]
+              .push_back(sourceFile);
             command.flags = compilerFlags;
             command.defines = compileDefines;
           }
@@ -2178,19 +2145,9 @@ public:
         for (std::map<std::string, CompileCommand>::iterator groupIter =
                commandPermutations.begin();
              groupIter != commandPermutations.end(); ++groupIter) {
-          const CompileCommand& command = groupIter->second;
-          std::stringstream ruleName;
-          ruleName << objectGroupRuleName << "-" << (groupNameCount++);
-          configObjectGroups.push_back(ruleName.str());
-
-          context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
           context.fc.WritePushScope();
 
-          context.fc.WriteArray("CompilerInputFiles",
-                                Wrap(command.sourceFiles, "'", "'"));
-
-          // Unity source files:
-          context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
+          const CompileCommand& command = groupIter->second;
 
           context.fc.WriteVariable("CompileDefineFlags",
                                    Quote(command.defines));
@@ -2200,21 +2157,61 @@ public:
             Quote(
               "$CompileFlags$ $CompileDefineFlags$ $CompilerCmdBaseFlags$"));
 
-          /*
-          if (Detection::DetectPrecompiledHeader(command.flags + " " +
-                  baseCompileFlags + " " + command.defines,
-                  preCompiledHeaderInput,
-                  preCompiledHeaderOutput,
-                  preCompiledHeaderOptions)
-          */
+          if (objectGroupLanguage == "RC") {
+            context.fc.WriteVariable("CompilerOutputExtension", Quote(".res"));
+          } else {
+            context.fc.WriteVariable(
+              "CompilerOutputExtension",
+              Quote("." + objectGroupLanguage + ".obj"));
+          }
+
+          std::map<std::string, std::vector<std::string> >::const_iterator
+            objectListIt;
+          for (objectListIt = command.sourceFiles.begin();
+               objectListIt != command.sourceFiles.end(); ++objectListIt) {
+            const std::string folderName(
+              Detection::GetLastFolderName(objectListIt->first));
+            std::stringstream ruleName;
+            ruleName << objectGroupRuleName << "-" << folderName << "-"
+                     << (groupNameCount++);
+
+            context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
+            context.fc.WritePushScope();
+
+            context.fc.WriteArray("CompilerInputFiles",
+                                  Wrap(objectListIt->second, "'", "'"));
+
+            configObjectGroups.push_back(ruleName.str());
+
+            std::string targetCompileOutDirectory =
+              Detection::DetectTargetCompileOutputDir(lg, target, configName);
+            context.fc.WriteVariable(
+              "CompilerOutputPath",
+              Quote(targetCompileOutDirectory + "/" + folderName));
+
+            // Unity source files:
+            context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
+
+            /*
+            if (Detection::DetectPrecompiledHeader(command.flags + " " +
+                    baseCompileFlags + " " + command.defines,
+                    preCompiledHeaderInput,
+                    preCompiledHeaderOutput,
+                    preCompiledHeaderOptions)
+            */
+            context.fc.WritePopScope();
+          }
+
           context.fc.WritePopScope();
         }
 
-        // Write an alias for this object group to group them all together
-        context.fc.WriteCommand("Alias", Quote(objectGroupRuleName));
-        context.fc.WritePushScope();
-        context.fc.WriteArray("Targets", Wrap(configObjectGroups, "'", "'"));
-        context.fc.WritePopScope();
+        if (!configObjectGroups.empty()) {
+          // Write an alias for this object group to group them all together
+          context.fc.WriteCommand("Alias", Quote(objectGroupRuleName));
+          context.fc.WritePushScope();
+          context.fc.WriteArray("Targets", Wrap(configObjectGroups, "'", "'"));
+          context.fc.WritePopScope();
+        }
 
         context.fc.WritePopScope();
       }
@@ -2267,6 +2264,16 @@ public:
           Detection::UnescapeFastbuildVariables(linkPath);
 
           linkPath = frameworkPath + linkPath;
+
+          if (target.IsExecutableWithExports()) {
+            const char* defFileFlag =
+              lg->GetMakefile()->GetDefinition("CMAKE_LINK_DEF_FILE_FLAG");
+            const std::string defFile =
+              gt->GetModuleDefinitionFile(configName);
+            if (!defFile.empty()) {
+              linkFlags += defFileFlag + defFile;
+            }
+          }
 
           context.fc.WriteVariable("LinkPath", "'" + linkPath + "'");
           context.fc.WriteVariable("LinkLibs", "'" + linkLibs + "'");
@@ -2497,7 +2504,7 @@ public:
 
         perTarget[targetName].push_back(aliasName);
 
-        if (!target->GetPropertyAsBool("EXCLUDE_FROM_ALL")) {
+        if (!Detection::IsExcludedFromAll(target)) {
           perConfig[configName].push_back(aliasName);
         }
       }

--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -265,11 +265,16 @@ public:
     return excluded;
   }
 
+#define FASTBUILD_DOLLAR_TAG "FASTBUILD_DOLLAR_TAG"
+
   static void UnescapeFastbuildVariables(std::string& string)
   {
     // Unescape the Fastbuild configName symbol with $
-    cmSystemTools::ReplaceString(string, "$$ConfigName$$", "$ConfigName$");
-    cmSystemTools::ReplaceString(string, "^$ConfigName^$", "$ConfigName$");
+    cmSystemTools::ReplaceString(string, "^", "^^");
+    cmSystemTools::ReplaceString(string, "$$", "^$");
+    cmSystemTools::ReplaceString(string, FASTBUILD_DOLLAR_TAG, "$");
+    // cmSystemTools::ReplaceString(string, "$$ConfigName$$", "$ConfigName$");
+    // cmSystemTools::ReplaceString(string, "^$ConfigName^$", "$ConfigName$");
   }
 
   static void ResolveFastbuildVariables(std::string& string,
@@ -381,6 +386,8 @@ public:
     std::string targetOutputReal;
     std::string targetOutputImplib;
     std::string targetOutputDir;
+    std::string targetOutputPDBDir;
+    std::string targetOutputCompilePDBDir;
   };
 
   static void DetectOutput(FastbuildTargetNames& targetNamesOut,
@@ -429,11 +436,30 @@ public:
         targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameReal;
     }
 
+    if (target.GetType() == cmTarget::EXECUTABLE ||
+        target.GetType() == cmTarget::STATIC_LIBRARY ||
+        target.GetType() == cmTarget::SHARED_LIBRARY ||
+        target.GetType() == cmTarget::MODULE_LIBRARY) {
+      targetNamesOut.targetOutputPDBDir = target.GetPDBDirectory(configName);
+      targetNamesOut.targetOutputPDBDir += "/";
+    }
+    if (target.GetType() <= cmTarget::OBJECT_LIBRARY) {
+      targetNamesOut.targetOutputCompilePDBDir =
+        target.GetCompilePDBPath(configName);
+      if (targetNamesOut.targetOutputCompilePDBDir.empty()) {
+        targetNamesOut.targetOutputCompilePDBDir =
+          target.GetSupportDirectory() + "/";
+      }
+    }
+
     // Make sure all obey the correct slashes
     cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutput);
     cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputImplib);
     cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputReal);
     cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputDir);
+    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputPDBDir);
+    cmSystemTools::ConvertToOutputSlashes(
+      targetNamesOut.targetOutputCompilePDBDir);
   }
 
   static void ComputeLinkCmds(std::vector<std::string>& linkCmds,
@@ -589,14 +615,19 @@ public:
     vars.Language = linkLanguage.c_str();
 
     std::string responseFlag;
-    vars.Objects = "$FB_INPUT_1_PLACEHOLDER$";
+    vars.Objects =
+      FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
     vars.LinkLibraries = "";
 
-    vars.ObjectDir = "$TargetOutDir$";
-    vars.Target = "$FB_INPUT_2_PLACEHOLDER$";
+    vars.ObjectDir = FASTBUILD_DOLLAR_TAG "TargetOutDir" FASTBUILD_DOLLAR_TAG;
+    vars.Target =
+      FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
 
-    vars.TargetSOName = "$TargetOutSO$";
-    vars.TargetPDB = "$TargetOutDir$$TargetNamePDB$";
+    vars.TargetSOName =
+      FASTBUILD_DOLLAR_TAG "TargetOutSO" FASTBUILD_DOLLAR_TAG;
+    vars.TargetPDB = FASTBUILD_DOLLAR_TAG
+      "TargetOutPDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
+      "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
 
     // Setup the target version.
     std::string targetVersionMajor;
@@ -615,9 +646,12 @@ public:
     vars.TargetVersionMajor = targetVersionMajor.c_str();
     vars.TargetVersionMinor = targetVersionMinor.c_str();
 
-    vars.Defines = "$CompileDefineFlags$";
-    vars.Flags = "$TargetFlags$";
-    vars.LinkFlags = "$LinkFlags$ $LinkPath$";
+    vars.Defines =
+      FASTBUILD_DOLLAR_TAG "CompileDefineFlags" FASTBUILD_DOLLAR_TAG;
+    vars.Flags = FASTBUILD_DOLLAR_TAG "TargetFlags" FASTBUILD_DOLLAR_TAG;
+    vars.LinkFlags = FASTBUILD_DOLLAR_TAG "LinkFlags" FASTBUILD_DOLLAR_TAG
+                                          " " FASTBUILD_DOLLAR_TAG
+                                          "LinkPath" FASTBUILD_DOLLAR_TAG;
     // Rule for linking library/executable.
     std::vector<std::string> linkCmds;
     ComputeLinkCmds(linkCmds, lg, target, gt, configName);
@@ -656,13 +690,18 @@ public:
     cmLocalGenerator::RuleVariables compileObjectVars;
     compileObjectVars.CMTarget = &target;
     compileObjectVars.Language = language.c_str();
-    compileObjectVars.Source = "$FB_INPUT_1_PLACEHOLDER$";
-    compileObjectVars.Object = "$FB_INPUT_2_PLACEHOLDER$";
-    compileObjectVars.ObjectDir = "$TargetOutputDir$";
+    compileObjectVars.Source =
+      FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+    compileObjectVars.Object =
+      FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
+    compileObjectVars.ObjectDir =
+      FASTBUILD_DOLLAR_TAG "TargetOutputDir" FASTBUILD_DOLLAR_TAG;
     compileObjectVars.ObjectFileDir = "";
     compileObjectVars.Flags = "";
     compileObjectVars.Defines = "";
-    compileObjectVars.TargetCompilePDB = "$TargetNamePDB$";
+    compileObjectVars.TargetCompilePDB = FASTBUILD_DOLLAR_TAG
+      "TargetOutCompilePDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
+      "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
 
     // Rule for compiling object file.
     std::string compileCmdVar = "CMAKE_";
@@ -740,9 +779,10 @@ public:
     for (; iter != end; ++iter) {
       const std::string& configName = *iter;
 
-      std::vector<cmSourceFile*> sourceFiles;
-      gt->GetSourceFiles(sourceFiles, configName);
-      for (std::vector<cmSourceFile*>::const_iterator i = sourceFiles.begin();
+      std::vector<const cmSourceFile*> sourceFiles;
+      gt->GetObjectSources(sourceFiles, configName);
+      for (std::vector<const cmSourceFile*>::const_iterator i =
+             sourceFiles.begin();
            i != sourceFiles.end(); ++i) {
         const std::string& lang = (*i)->GetLanguage();
         if (!lang.empty()) {
@@ -948,14 +988,24 @@ public:
         cmMakefile* makefile = lg->GetMakefile();
         cmCustomCommandGenerator ccg(*cc, configName, makefile);
 
+        std::string workingDirectory = ccg.GetWorkingDirectory();
+        if (workingDirectory.empty()) {
+          workingDirectory = makefile->GetCurrentOutputDirectory();
+          workingDirectory += "/";
+        }
+
         // Take the dependencies listed and split into targets and files.
         const std::vector<std::string>& depends = ccg.GetDepends();
         for (std::vector<std::string>::const_iterator iter = depends.begin();
              iter != depends.end(); ++iter) {
-          const std::string& dep = *iter;
+          std::string dep = *iter;
 
           bool isTarget = gg->FindTarget(dep) != NULL;
           if (!isTarget) {
+            if (!cmSystemTools::FileIsFullPath(dep.c_str())) {
+              dep = workingDirectory + dep;
+            }
+
             inputs.push_back(dep);
           }
         }
@@ -1130,8 +1180,13 @@ public:
   static bool isConfigDependant(const cmCustomCommandGenerator& ccg)
   {
     typedef std::vector<std::string> StringVector;
-    const StringVector& outputs = ccg.GetOutputs();
-    const StringVector& byproducts = ccg.GetByproducts();
+    StringVector outputs = ccg.GetOutputs();
+    StringVector byproducts = ccg.GetByproducts();
+
+    std::for_each(outputs.begin(), outputs.end(),
+                  &Detection::UnescapeFastbuildVariables);
+    std::for_each(byproducts.begin(), byproducts.end(),
+                  &Detection::UnescapeFastbuildVariables);
 
     // Make sure that the outputs don't depend on the config name
     for (StringVector::const_iterator iter = outputs.begin();
@@ -1156,7 +1211,9 @@ public:
                                        const std::string& version,
                                        std::vector<std::string>& extraFiles)
   {
-    // Output a list of files that are relative to $CompilerRoot$.
+    // Output a list of files that are relative to $CompilerRoot$
+    return;
+
     if (compilerID == "MSVC") {
       if (version.compare(0, 3, "18.") != std::string::npos) {
         // Using vs2013
@@ -1241,7 +1298,8 @@ public:
     cmLocalFastbuildGenerator* lg;
   };
   typedef std::map<const cmTarget*, TargetGenerationContext> TargetContextMap;
-  typedef std::map<const cmCustomCommand*, std::string> CustomCommandAliasMap;
+  typedef std::map<const cmCustomCommand*, std::set<std::string> >
+    CustomCommandAliasMap;
   typedef Detection::OrderedTargetSet OrderedTargets;
 
   struct GenerationContext
@@ -1416,8 +1474,10 @@ public:
 
     // Sort targets
 
-    WriteTargetDefinitions(context);
-    WriteAliases(context);
+    WriteTargetDefinitions(context, false);
+    WriteAliases(context, false);
+    WriteTargetDefinitions(context, true);
+    WriteAliases(context, true);
   }
 
   static void WritePlaceholders(GenerationContext& context)
@@ -1590,7 +1650,8 @@ public:
                                  cmLocalFastbuildGenerator* lg,
                                  cmTarget& target,
                                  const std::string& configName,
-                                 const std::string& targetName)
+                                 std::string& targetName,
+                                 const std::string& hostTargetName)
   {
     cmMakefile* makefile = lg->GetMakefile();
 
@@ -1637,22 +1698,39 @@ public:
       // If it has then just drop an alias here to the original
       CustomCommandAliasMap::iterator findResult =
         context.customCommandAliases.find(cc);
-      if (findResult != context.customCommandAliases.end() &&
-          !Detection::isConfigDependant(ccg)) {
-        // This command has already been generated.
-        // So just drop an alias.
-        std::vector<std::string> targets;
-        targets.push_back(findResult->second);
-
-        context.fc.WriteCommand("Alias", Quote(targetName));
-        context.fc.WritePushScope();
-        {
-          context.fc.WriteArray("Targets", Wrap(targets));
+      if (findResult != context.customCommandAliases.end()) {
+        const std::set<std::string>& aliases = findResult->second;
+        if (aliases.find(targetName) != aliases.end()) {
+          // This target has already been generated
+          // with the correct name somewhere else.
+          return;
         }
-        context.fc.WritePopScope();
-        return;
+        if (!Detection::isConfigDependant(ccg)) {
+          // This command has already been generated.
+          // But under a different name so setup an alias to redirect
+          // No merged outputs, so this command must always be run.
+          // Make it's name unique to its host target
+          targetName += "-";
+          targetName += hostTargetName;
+
+          std::vector<std::string> targets;
+          targets.push_back(*findResult->second.begin());
+
+          context.fc.WriteCommand("Alias", Quote(targetName));
+          context.fc.WritePushScope();
+          {
+            context.fc.WriteArray("Targets", Wrap(targets));
+          }
+          context.fc.WritePopScope();
+          return;
+        }
       }
-      context.customCommandAliases[cc] = targetName;
+      context.customCommandAliases[cc].insert(targetName);
+    } else {
+      // No merged outputs, so this command must always be run.
+      // Make it's name unique to its host target
+      targetName += "-";
+      targetName += hostTargetName;
     }
 
     // Take the dependencies listed and split into targets and files.
@@ -1675,14 +1753,20 @@ public:
     const std::string shellExt = ".sh";
 #endif
 
-    std::string scriptFileName(ccg.GetWorkingDirectory() + targetName +
-                               ".bat");
+    std::string workingDirectory = ccg.GetWorkingDirectory();
+    if (workingDirectory.empty()) {
+      workingDirectory = makefile->GetCurrentOutputDirectory();
+      workingDirectory += "/";
+    }
+
+    std::string scriptFileName(workingDirectory + targetName + ".bat");
     cmsys::ofstream scriptFile(scriptFileName.c_str());
 
     for (unsigned i = 0; i != ccg.GetNumberOfCommands(); ++i) {
       std::string args;
       ccg.AppendArguments(i, args);
       cmSystemTools::ReplaceString(args, "$$", "$");
+      cmSystemTools::ReplaceString(args, FASTBUILD_DOLLAR_TAG, "$");
 #ifdef _WIN32
       // in windows batch, '%' is a special character that needs to be doubled
       // to be escaped
@@ -1691,9 +1775,10 @@ public:
       Detection::ResolveFastbuildVariables(args, configName);
 
       std::string command(ccg.GetCommand(i));
+      cmSystemTools::ReplaceString(command, FASTBUILD_DOLLAR_TAG, "$");
       Detection::ResolveFastbuildVariables(command, configName);
 
-      scriptFile << command << args << std::endl;
+      scriptFile << Quote(command, "\"") << args << std::endl;
     }
 
     // Write out an exec command
@@ -1713,6 +1798,11 @@ public:
     }
     */
 
+    std::for_each(inputs.begin(), inputs.end(),
+                  &Detection::UnescapeFastbuildVariables);
+    std::for_each(mergedOutputs.begin(), mergedOutputs.end(),
+                  &Detection::UnescapeFastbuildVariables);
+
     context.fc.WriteCommand("Exec", Quote(targetName));
     context.fc.WritePushScope();
     {
@@ -1723,12 +1813,12 @@ public:
 #else
       context.fc.WriteVariable("ExecExecutable", Quote(scriptFileName));
 #endif
-      if (!ccg.GetWorkingDirectory().empty())
-        context.fc.WriteVariable("ExecWorkingDir",
-                                 Quote(ccg.GetWorkingDirectory()));
+      if (!workingDirectory.empty()) {
+        context.fc.WriteVariable("ExecWorkingDir", Quote(workingDirectory));
+      }
 
       if (inputs.empty()) {
-        inputs.push_back("dummy-in");
+        // inputs.push_back("dummy-in");
       }
       context.fc.WriteArray("ExecInput", Wrap(inputs));
 
@@ -1785,10 +1875,11 @@ public:
 
         std::stringstream customCommandTargetName;
         customCommandTargetName << baseName << (commandCount++);
-        customCommandTargets.push_back(customCommandTargetName.str());
 
+        std::string customCommandTargetNameStr = customCommandTargetName.str();
         WriteCustomCommand(context, &cc, lg, target, configName,
-                           customCommandTargetName.str());
+                           customCommandTargetNameStr, targetName);
+        customCommandTargets.push_back(customCommandTargetNameStr);
       }
 
       // Write an alias for this object group to group them all together
@@ -1840,7 +1931,7 @@ public:
         // Write the custom command build rules for each configuration
         int commandCount = 1;
         std::string customCommandNameBase =
-          targetName + "-CustomCommand-" + configName + "-";
+          "CustomCommand-" + configName + "-";
         for (std::vector<cmSourceFile const*>::iterator ccIter =
                customCommands.begin();
              ccIter != customCommands.end(); ++ccIter) {
@@ -1852,11 +1943,14 @@ public:
             << "-"
             << cmSystemTools::GetFilenameName(sourceFile->GetFullPath());
           ;
-          customCommandTargets.push_back(customCommandTargetName.str());
 
+          std::string customCommandTargetNameStr =
+            customCommandTargetName.str();
           WriteCustomCommand(context, sourceFile->GetCustomCommand(), lg,
-                             target, configName,
-                             customCommandTargetName.str());
+                             target, configName, customCommandTargetNameStr,
+                             targetName);
+
+          customCommandTargets.push_back(customCommandTargetNameStr);
         }
 
         std::string customCommandGroupName =
@@ -1978,11 +2072,19 @@ public:
                                  Quote(targetNames.targetOutputReal));
         context.fc.WriteVariable("TargetOutDir",
                                  Quote(targetNames.targetOutputDir));
+        context.fc.WriteVariable("TargetOutCompilePDBDir",
+                                 Quote(targetNames.targetOutputCompilePDBDir));
+        context.fc.WriteVariable("TargetOutPDBDir",
+                                 Quote(targetNames.targetOutputPDBDir));
+
+        // Compile directory always needs to exist
+        EnsureDirectoryExists(targetNames.targetOutputCompilePDBDir, context);
 
         if (target.GetType() != cmTarget::OBJECT_LIBRARY) {
           // on Windows the output dir is already needed at compile time
           // ensure the directory exists (OutDir test)
           EnsureDirectoryExists(targetNames.targetOutputDir, context);
+          EnsureDirectoryExists(targetNames.targetOutputPDBDir, context);
         }
       }
 
@@ -2079,7 +2181,9 @@ public:
           std::string compileCmd;
           Detection::DetectBaseCompileCommand(compileCmd, lg, target,
                                               objectGroupLanguage);
-          Detection::UnescapeFastbuildVariables(compileCmd);
+
+          // No need to double unescape the variables
+          // Detection::UnescapeFastbuildVariables(compileCmd);
 
           std::string executable;
           Detection::SplitExecutableAndFlags(compileCmd, executable,
@@ -2286,7 +2390,9 @@ public:
                                                   configName)) {
             return;
           }
-          Detection::UnescapeFastbuildVariables(linkCmd);
+          // No need to do this, because the function above has already escaped
+          // things appropriately
+          // Detection::UnescapeFastbuildVariables(linkCmd);
 
           std::string executable;
           std::string flags;
@@ -2315,6 +2421,9 @@ public:
               context.self, target, configName, extraDependencies);
             Detection::DetectTargetLinkDependencies(target, configName,
                                                     extraDependencies);
+
+            std::for_each(extraDependencies.begin(), extraDependencies.end(),
+                          Detection::UnescapeFastbuildVariables);
 
             context.fc.WriteArray("Libraries",
                                   Wrap(extraDependencies, "'", "'"), "+");
@@ -2426,9 +2535,11 @@ public:
     WriteTargetDefinition(context, lg, target);
   }
 
-  static void WriteTargetDefinitions(GenerationContext& context)
+  static void WriteTargetDefinitions(GenerationContext& context,
+                                     bool outputGlobals)
   {
-    context.fc.WriteSectionHeader("Target Definitions");
+    context.fc.WriteSectionHeader((outputGlobals) ? "Global Target Definitions"
+                                                  : "Target Definitions");
 
     // Now iterate each target in order
     for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
@@ -2446,6 +2557,14 @@ public:
 
       cmTarget* target = findResult->second.target;
       cmLocalFastbuildGenerator* lg = findResult->second.lg;
+
+      if (target->GetType() == cmTarget::GLOBAL_TARGET) {
+        if (!outputGlobals)
+          continue;
+      } else {
+        if (outputGlobals)
+          continue;
+      }
 
       switch (target->GetType()) {
         case cmTarget::EXECUTABLE:
@@ -2465,7 +2584,7 @@ public:
     }
   }
 
-  static void WriteAliases(GenerationContext& context)
+  static void WriteAliases(GenerationContext& context, bool outputGlobals)
   {
     context.fc.WriteSectionHeader("Aliases");
 
@@ -2494,6 +2613,14 @@ public:
       cmTarget* target = findResult->second.target;
       const std::string& targetName = target->GetName();
 
+      if (target->GetType() == cmTarget::GLOBAL_TARGET) {
+        if (!outputGlobals)
+          continue;
+      } else {
+        if (outputGlobals)
+          continue;
+      }
+
       // Define compile flags
       std::vector<std::string>::const_iterator
         iter = context.self->GetConfigurations().begin(),
@@ -2510,16 +2637,26 @@ public:
       }
     }
 
-    context.fc.WriteComment("Per config");
-    for (TargetListMap::iterator iter = perConfig.begin();
-         iter != perConfig.end(); ++iter) {
-      const std::string& configName = iter->first;
-      const std::vector<std::string>& targets = iter->second;
+    if (!outputGlobals) {
+      context.fc.WriteComment("Per config");
+      std::vector<std::string> aliasTargets;
+      for (TargetListMap::iterator iter = perConfig.begin();
+           iter != perConfig.end(); ++iter) {
+        const std::string& configName = iter->first;
+        const std::vector<std::string>& targets = iter->second;
 
-      context.fc.WriteCommand("Alias", "'" + configName + "'");
-      context.fc.WritePushScope();
-      context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
-      context.fc.WritePopScope();
+        context.fc.WriteCommand("Alias", Quote(configName));
+        context.fc.WritePushScope();
+        context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
+        context.fc.WritePopScope();
+
+        aliasTargets.clear();
+        aliasTargets.push_back(configName);
+        context.fc.WriteCommand("Alias", Quote("ALL_BUILD-" + configName));
+        context.fc.WritePushScope();
+        context.fc.WriteArray("Targets", Wrap(aliasTargets, "'", "'"));
+        context.fc.WritePopScope();
+      }
     }
 
     context.fc.WriteComment("Per targets");
@@ -2534,12 +2671,14 @@ public:
       context.fc.WritePopScope();
     }
 
-    context.fc.WriteComment("All");
-    context.fc.WriteCommand("Alias", "'All'");
-    context.fc.WritePushScope();
-    context.fc.WriteArray("Targets",
-                          Wrap(context.self->GetConfigurations(), "'", "'"));
-    context.fc.WritePopScope();
+    if (!outputGlobals) {
+      context.fc.WriteComment("All");
+      context.fc.WriteCommand("Alias", "'All'");
+      context.fc.WritePushScope();
+      context.fc.WriteArray("Targets",
+                            Wrap(context.self->GetConfigurations(), "'", "'"));
+      context.fc.WritePopScope();
+    }
   }
 };
 
@@ -2595,7 +2734,7 @@ void cmGlobalFastbuildGenerator::Generate()
 //----------------------------------------------------------------------------
 void cmGlobalFastbuildGenerator::GenerateBuildCommand(
   std::vector<std::string>& makeCommand, const std::string& makeProgram,
-  const std::string& /*projectName*/, const std::string& /*projectDir*/,
+  const std::string& projectName, const std::string& projectDir,
   const std::string& targetName, const std::string& config, bool /*fast*/,
   bool /*verbose*/, std::vector<std::string> const& /*makeOptions*/)
 {
@@ -2629,6 +2768,13 @@ void cmGlobalFastbuildGenerator::GenerateBuildCommand(
     targetSelected += "-" + configSelected;
   }
 
+  // Hunt the fbuild.bff file in the directory above
+  std::string configFile;
+  if (!cmSystemTools::FileExists(projectDir + "fbuild.bff")) {
+    configFile = cmSystemTools::FileExistsInParentDirectories(
+      "fbuild.bff", projectDir.c_str(), "");
+  }
+
   // Build the command
   makeCommand.push_back(makeProgramSelected);
 
@@ -2643,6 +2789,11 @@ void cmGlobalFastbuildGenerator::GenerateBuildCommand(
 
   makeCommand.push_back("-showcmds");
   makeCommand.push_back("-ide");
+
+  if (!configFile.empty()) {
+    makeCommand.push_back("-config");
+    makeCommand.push_back(configFile);
+  }
 
   // Add the target-config to the command
   if (!targetSelected.empty()) {
@@ -2680,7 +2831,7 @@ void cmGlobalFastbuildGenerator::ComputeTargetObjectDirectory(
 //----------------------------------------------------------------------------
 const char* cmGlobalFastbuildGenerator::GetCMakeCFGIntDir() const
 {
-  return "$ConfigName$";
+  return FASTBUILD_DOLLAR_TAG "ConfigName" FASTBUILD_DOLLAR_TAG;
 }
 
 //----------------------------------------------------------------------------

--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -1,109 +1,135 @@
 
 /*============================================================================
-        CMake - Cross Platform Makefile Generator
-        Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+    CMake - Cross Platform Makefile Generator
+    Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
 
-        Distributed under the OSI-approved BSD License (the "License");
-        see accompanying file Copyright.txt for details.
+    Distributed under the OSI-approved BSD License (the "License");
+    see accompanying file Copyright.txt for details.
 
-        This software is distributed WITHOUT ANY WARRANTY; without even the
-        implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE.
-        See the License for more information.
+    This software is distributed WITHOUT ANY WARRANTY; without even the
+    implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the License for more information.
 ============================================================================*/
 /*============================================================================
-        Development progress:
+    Development progress:
 
-        Tasks/Issues:
-         - Execute unit tests against the generator somehow
-         - Fix target aliases being repeated in the output
-         - Fix cmake build using fastbuild (currently appears configuration
-incorrect)
-         - Running some of the Cmake generation, the pdb files can't be deleted
-(shows up errors)
-         - Depends upon visual studio generator code to sort dependencies
-         - When generating CMAKE from scratch, it sometimes errors with fortran
-complaints and fails generation?
-         a re-run will succeed.
-         - Linker for msvc uses the cmake command to callback. Don't think this
-is an issue since
-         I think compilation is the part that gets distributed anyway.
-         But it might mean that the cache has trouble calculating deps for
+    Tasks/Issues:
+     - Linker for msvc uses the cmake command to callback. Don't think this is
+an issue since
+     I think compilation is the part that gets distributed anyway.
+     But it might mean that the cache has trouble calculating deps for
 obj->lib/exe.
-         Not sure if Fastbuild supports that anyway yet
-         - Need to sort custom build commands by their outputs
+     Not sure if Fastbuild supports that anyway yet
+     - Need to sort custom build commands by their outputs
 
-        Fastbuild bugs:
-         - Defining prebuild dependencies that don't exist, causes the error
-output when that
-         target is actually defined. Rather than originally complaining that
-the target
-         doesn't exist where the reference is attempted.
-         - Parsing strings with double $$ doesn't generate a nice error
-         - Undocumented that you can escape a $ with ^$
-         - ExecInputs is invalid empty
-         - Would be great if you could define dummy targets (maybe blank
-aliases?)
-         - Exec nodes need to not worry about dummy output files not being
-created
-         - Would be nice if nodes didn't need to be completely in order. But
-then cycles would be possible
-         - Implib directory is not created for exeNodes (DLLs work now though)
+    Fastbuild bugs:
+     - Defining prebuild dependencies that don't exist, causes the error output
+when that
+     target is actually defined. Rather than originally complaining that the
+target
+     doesn't exist where the reference is attempted.
+     - Parsing strings with double $$ doesn't generate a nice error
+     - Undocumented that you can escape a $ with ^$
+     - ExecInputs is invalid empty
+     - Would be great if you could define dummy targets (maybe blank aliases?)
+     - Exec nodes need to not worry about dummy output files not being created
+     - Would be nice if nodes didn't need to be completely in order. But then
+cycles would be possible
+     - Implib directory is not created for exeNodes (DLLs work now though)
 
-        Limitations:
-         - Only tested/working with MSVC
+    Limitations:
+     - Only tested/working with MSVC
 
-        Notes:
-         - Understanding Custom Build Steps and Build Events
-                 https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
-         very useful documentation detailing the order of execution
-         of standard MSVC events. This is useful to determine correct
-         behaviour of fastbuild generator (view a project generated to MSVC,
-         then apply the same rules/assumptions back into fastbuild).
-         i.e. Custom rules are always executed first.
+    Notes:
+     - Understanding Custom Build Steps and Build Events
+         https://msdn.microsoft.com/en-us/library/e85wte0k.aspx
+     very useful documentation detailing the order of execution
+     of standard MSVC events. This is useful to determine correct
+     behaviour of fastbuild generator (view a project generated to MSVC,
+     then apply the same rules/assumptions back into fastbuild).
+     i.e. Custom rules are always executed first.
 
-        Current list of unit tests failing:
-
-        91% tests passed, 32 tests failed out of 371
-        Total Test time (real) = 1479.86 sec
+    Current list of unit tests failing:
+================ 3.2 ===========================
+    91% tests passed, 32 tests failed out of 371
+    Total Test time (real) = 1479.86 sec
 
 The following tests FAILED:
-         59 - Preprocess (Failed)
-         60 - ExportImport (Failed)
-         68 - StagingPrefix (Failed)
-         70 - ConfigSources (Failed)
-         79 - Module.GenerateExportHeader (Failed)
-        101 - SubProject-Stage2 (Failed)
-        113 - BuildDepends (Failed)
-        114 - SimpleInstall (Failed)
-        115 - SimpleInstall-Stage2 (Failed)
-        127 - complex (Failed)
-        128 - complexOneConfig (Failed)
-        131 - ExternalProject (Failed)
-        132 - ExternalProjectLocal (Failed)
-        133 - ExternalProjectUpdateSetup (Failed)
-        134 - ExternalProjectUpdate (Failed)
-        151 - Plugin (Failed)
-        157 - PrecompiledHeader (Failed)
-        184 - CTestConfig.Script.Debug (Failed)
-        185 - CTestConfig.Dashboard.Debug (Failed)
-        186 - CTestConfig.Script.MinSizeRel (Failed)
-        187 - CTestConfig.Dashboard.MinSizeRel (Failed)
-        188 - CTestConfig.Script.Release (Failed)
-        189 - CTestConfig.Dashboard.Release (Failed)
-        190 - CTestConfig.Script.RelWithDebInfo (Failed)
-        191 - CTestConfig.Dashboard.RelWithDebInfo (Failed)
-        197 - CMakeCommands.target_compile_options (Failed)
-        238 - CMakeOnly.CheckStructHasMember (Failed)
-        275 - RunCMake.Configure (Failed)
-        331 - RunCMake.File_Generate (Failed)
-        371 - CMake.CheckSourceTree (Failed)
+77 - Module.ExternalData (Failed) -- target already defined
+108 - CustomCommandByproducts (Failed) -- dependencies problem, source files
+generated by a target is required by another
+112 - BuildDepends (Failed) -- same problem as RunCMake.BuildDepends ?
+113 - SimpleInstall (Failed) -- another instance of Fastbuild already running
+in the same directory
+114 - SimpleInstall-Stage2 (Failed) -- depends upon previous test I guess
+132 - ExternalProjectUpdateSetup (Failed) -- generator bug; rule already
+defined
+133 - ExternalProjectUpdate (Failed) -- generator bug; rule already defined
+274 - RunCMake.Configure (Failed) -- same problem as RunCMake.BuildDepends ?
+370 - CMake.CheckSourceTree (Failed) -- does not work with Ninja either,
+environment problem ?
+
+================ 3.3 ===========================
+97% tests passed, 11 tests failed out of 381
+
+Regressions:
+274 - RunCMake.CMP0060 (Failed)
+================ 3.4 ===========================
+95% tests passed, 19 tests failed out of 397
+
+Regressions:
+280 - RunCMake.BuildDepends (Failed) -- add dependency on the manifest file
+this is the Ninja code that does it
+      std::vector<cmSourceFile const*> manifest_srcs;
+      this->GeneratorTarget->GetManifests(manifest_srcs, configName);
+      for (std::vector<cmSourceFile const*>::iterator mi =
+manifest_srcs.begin();
+           mi != manifest_srcs.end(); ++mi) {
+        command.sourceFiles[srcFile->GetLocation().GetDirectory()].push_back(
+          sourceFile);
+      }
+366 - RunCMake.AutoExportDll (Failed) -- very specific, auto-generation of .def
+      file. get the logic from ninja and copy/paste what is required
+
+================ 3.5 ===========================
+94% tests passed, 23 tests failed out of 398
+
+Regressions:
+109 - CustomCommand (Failed) -- rule already defined; fix ExternalProjectUpdate
+and then try again
+
+================ 3.7 ===========================
+most of these look like the manifest.res issue where two binaries have the same
+manifest file and try to write it at the same time
+94% tests passed, 23 tests failed out of 398
+
+The following tests FAILED:
+        132 - ExternalProject (Failed)
+
+================ master post 3.7 ===========================
+
+95% tests passed, 22 tests failed out of 406
+
+Label Time Summary:
+Label1    =   0.88 sec (1 test)
+Label2    =   0.88 sec (1 test)
+
+Total Test time (real) = 809.31 sec
+
+The following tests FAILED:
+         75 - BundleUtilities (Failed)
+         76 - CMakeBuildTest (Failed)
+        276 - RunCMake.CMP0060 (Failed)
+        281 - RunCMake.AndroidTestUtilities (Failed)
+        345 - RunCMake.try_compile (Failed) -- CMP0066 not honored
+        362 - RunCMake.CommandLine (Failed)
+        372 - RunCMake.CrosscompilingEmulator (Failed)
+
 ============================================================================*/
 #include "cmGlobalFastbuildGenerator.h"
 
 #include "cmComputeLinkInformation.h"
 #include "cmCustomCommandGenerator.h"
-#include "cmGeneratedFileStream.h"
 #include "cmGeneratorTarget.h"
 #include "cmGlobalGeneratorFactory.h"
 #include "cmGlobalVisualStudioGenerator.h"
@@ -115,2582 +141,804 @@ The following tests FAILED:
 #include <assert.h>
 #include <cmsys/Encoding.hxx>
 
-static const char fastbuildGeneratorName[] = "Fastbuild";
+#include "cmFastbuildTargetGenerator.h"
 
-class cmGlobalFastbuildGenerator::Factory : public cmGlobalGeneratorFactory
-{
-public:
-  Factory() {}
-
-  cmGlobalGenerator* CreateGlobalGenerator(const std::string& name) const
-  {
-    if (name == (fastbuildGeneratorName)) {
-      return new cmGlobalFastbuildGenerator();
-    }
-    return NULL;
-  }
-
-  void GetDocumentation(cmDocumentationEntry& entry) const
-  {
-    entry.Name = fastbuildGeneratorName;
-    entry.Brief = "Generates fastbuild project files.";
-  }
-
-  void GetGenerators(std::vector<std::string>& names) const
-  {
-    names.push_back(fastbuildGeneratorName);
-  }
-};
-
-//----------------------------------------------------------------------------
-class cmGlobalFastbuildGenerator::Detail
-{
-public:
-  class FileContext;
-  class Definition;
-  class Detection;
-  class Generation;
-};
-
-//----------------------------------------------------------------------------
-class cmGlobalFastbuildGenerator::Detail::FileContext
-{
-public:
-  FileContext(cmGeneratedFileStream& afout)
-    : fout(afout)
-  {
-  }
-
-  void WriteComment(const std::string& comment)
-  {
-    fout << linePrefix << ";" << comment << "\n";
-  }
-
-  void WriteBlankLine() { fout << "\n"; }
-
-  void WriteHorizontalLine()
-  {
-    fout << ";----------------------------------------------------------------"
-            "---------------\n";
-  }
-
-  void WriteSectionHeader(const char* section)
-  {
-    fout << "\n";
-    WriteHorizontalLine();
-    WriteComment(section);
-    WriteHorizontalLine();
-  }
-
-  void WritePushScope(char begin = '{', char end = '}')
-  {
-    fout << linePrefix << begin << "\n";
-    linePrefix += "\t";
-    closingScope += end;
-  }
-
-  void WritePushScopeStruct() { WritePushScope('[', ']'); }
-
-  void WritePopScope()
-  {
-    assert(!linePrefix.empty());
-    linePrefix.resize(linePrefix.size() - 1);
-
-    fout << linePrefix << closingScope[closingScope.size() - 1] << "\n";
-
-    closingScope.resize(closingScope.size() - 1);
-  }
-
-  void WriteVariable(const std::string& key, const std::string& value,
-                     const std::string& operation = "=")
-  {
-    fout << linePrefix << "." << key << " " << operation << " " << value
-         << "\n";
-  }
-
-  void WriteCommand(const std::string& command,
-                    const std::string& value = std::string())
-  {
-    fout << linePrefix << command;
-    if (!value.empty()) {
-      fout << "(" << value << ")";
-    }
-    fout << "\n";
-  }
-
-  void WriteArray(const std::string& key,
-                  const std::vector<std::string>& values,
-                  const std::string& operation = "=")
-  {
-    WriteVariable(key, "", operation);
-    WritePushScope();
-    size_t size = values.size();
-    for (size_t index = 0; index < size; ++index) {
-      const std::string& value = values[index];
-      bool isLast = index == size - 1;
-
-      fout << linePrefix << value;
-      if (!isLast) {
-        fout << ',';
-      }
-      fout << "\n";
-    }
-    WritePopScope();
-  }
-
-private:
-  cmGeneratedFileStream& fout;
-  std::string linePrefix;
-  std::string closingScope;
-};
-
-//----------------------------------------------------------------------------
-class cmGlobalFastbuildGenerator::Detail::Detection
-{
-public:
-  static std::string GetLastFolderName(const std::string& string)
-  {
-    return string.substr(string.rfind('/'));
-  }
-
-  static bool IsExcludedFromAll(cmTarget* target)
-  {
-    bool excluded = target->GetPropertyAsBool("EXCLUDE_FROM_ALL");
-    cmLocalGenerator* lg = target->GetMakefile()->GetLocalGenerator();
-    while (lg->GetParent() != 0 && !excluded) {
-      excluded = lg->GetMakefile()->GetPropertyAsBool("EXCLUDE_FROM_ALL");
-      lg = lg->GetParent();
-    }
-
-    return excluded;
-  }
-
+const char* cmGlobalFastbuildGenerator::FASTBUILD_DOLLAR_TAG =
+  "FASTBUILD_DOLLAR_TAG";
 #define FASTBUILD_DOLLAR_TAG "FASTBUILD_DOLLAR_TAG"
 
-  static void UnescapeFastbuildVariables(std::string& string)
-  {
-    // Unescape the Fastbuild configName symbol with $
-    cmSystemTools::ReplaceString(string, "^", "^^");
-    cmSystemTools::ReplaceString(string, "$$", "^$");
-    cmSystemTools::ReplaceString(string, FASTBUILD_DOLLAR_TAG, "$");
-    // cmSystemTools::ReplaceString(string, "$$ConfigName$$", "$ConfigName$");
-    // cmSystemTools::ReplaceString(string, "^$ConfigName^$", "$ConfigName$");
+cmGlobalFastbuildGenerator::Detail::FileContext::FileContext()
+{
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::setFileName(
+  const std::string fileName)
+{
+  fout.Open(fileName.c_str());
+  fout.SetCopyIfDifferent(true);
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::close()
+{
+  // Close file
+  fout.Close();
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteComment(
+  const std::string& comment)
+{
+  fout << linePrefix << ";" << comment << "\n";
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteBlankLine()
+{
+  fout << "\n";
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteHorizontalLine()
+{
+  fout << ";----------------------------------------------------------------"
+          "---------------\n";
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteSectionHeader(
+  const char* section)
+{
+  fout << "\n";
+  WriteHorizontalLine();
+  WriteComment(section);
+  WriteHorizontalLine();
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WritePushScope(
+  char begin, char end)
+{
+  fout << linePrefix << begin << "\n";
+  linePrefix += "\t";
+  closingScope += end;
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WritePushScopeStruct()
+{
+  WritePushScope('[', ']');
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WritePopScope()
+{
+  assert(!linePrefix.empty());
+  linePrefix.resize(linePrefix.size() - 1);
+
+  fout << linePrefix << closingScope[closingScope.size() - 1] << "\n";
+
+  closingScope.resize(closingScope.size() - 1);
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteVariable(
+  const std::string& key, const std::string& value,
+  const std::string& operation)
+{
+  fout << linePrefix << "." << key << " " << operation << " " << value << "\n";
+}
+
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteCommand(
+  const std::string& command, const std::string& value)
+{
+  fout << linePrefix << command;
+  if (!value.empty()) {
+    fout << "(" << value << ")";
   }
+  fout << "\n";
+}
 
-  static void ResolveFastbuildVariables(std::string& string,
-                                        const std::string& configName)
-  {
-    // Replace Fastbuild configName with the config name
-    cmSystemTools::ReplaceString(string, "$ConfigName$", configName);
+void cmGlobalFastbuildGenerator::Detail::FileContext::WriteArray(
+  const std::string& key, const std::vector<std::string>& values,
+  const std::string& operation)
+{
+  WriteVariable(key, "", operation);
+  WritePushScope();
+  size_t size = values.size();
+  for (size_t index = 0; index < size; ++index) {
+    const std::string& value = values[index];
+    bool isLast = index == size - 1;
+
+    fout << linePrefix << value;
+    if (!isLast) {
+      fout << ',';
+    }
+    fout << "\n";
   }
+  WritePopScope();
+}
 
-  static std::string BuildCommandLine(const std::vector<std::string>& cmdLines)
-  {
-#ifdef _WIN32
-    const char* cmdExe = "cmd.exe";
-    std::string cmdExeAbsolutePath = cmSystemTools::FindProgram(cmdExe);
-#endif
-
-    // If we have no commands but we need to build a command anyway, use ":".
-    // This happens when building a POST_BUILD value for link targets that
-    // don't use POST_BUILD.
-    if (cmdLines.empty()) {
-#ifdef _WIN32
-      return cmdExeAbsolutePath + " /C \"cd .\"";
-#else
-      return ":";
-#endif
-    }
-
-    std::ostringstream cmd;
-    for (std::vector<std::string>::const_iterator li = cmdLines.begin();
-         li != cmdLines.end(); ++li)
-#ifdef _WIN32
-    {
-      if (li != cmdLines.begin()) {
-        cmd << " && ";
-      } else if (cmdLines.size() > 1) {
-        cmd << cmdExeAbsolutePath << " /C \"";
-      }
-      cmd << *li;
-    }
-    if (cmdLines.size() > 1) {
-      cmd << "\"";
-    }
-#else
-    {
-      if (li != cmdLines.begin()) {
-        cmd << " && ";
-      }
-      cmd << *li;
-    }
-#endif
-    std::string cmdOut = cmd.str();
-    UnescapeFastbuildVariables(cmdOut);
-
-    return cmdOut;
-  }
-
-  static void DetectConfigurations(cmGlobalFastbuildGenerator* self,
-                                   cmMakefile* mf,
-                                   std::vector<std::string>& configurations)
-  {
-    // process the configurations
-    const char* configList = self->GetCMakeInstance()->GetCacheDefinition(
-      "CMAKE_CONFIGURATION_TYPES");
-    if (configList) {
-      std::vector<std::string> argsOut;
-      cmSystemTools::ExpandListArgument(configList, argsOut);
-      for (std::vector<std::string>::iterator iter = argsOut.begin();
-           iter != argsOut.end(); ++iter) {
-        if (std::find(configurations.begin(), configurations.end(), *iter) ==
-            configurations.end()) {
-          configurations.push_back(*iter);
-        }
-      }
-    }
-
-    // default to at least Debug and Release
-    if (configurations.size() == 0) {
-      configurations.push_back("Debug");
-      configurations.push_back("Release");
-      configurations.push_back("MinSizeRel");
-      configurations.push_back("RelWithDebInfo");
-    }
-
-    // Reset the entry to have a semi-colon separated list.
-    std::string configs = configurations[0];
-    for (unsigned int i = 1; i < configurations.size(); ++i) {
-      configs += ";";
-      configs += configurations[i];
-    }
-
-    // Add a cache definition
-    mf->AddCacheDefinition(
-      "CMAKE_CONFIGURATION_TYPES", configs.c_str(),
-      "Semicolon separated list of supported configuration types, "
-      "only supports Debug, Release, MinSizeRel, and RelWithDebInfo, "
-      "anything else will be ignored.",
-      cmCacheManager::STRING);
-  }
-
-  struct FastbuildTargetNames
-  {
-    std::string targetNameOut;
-    std::string targetNameReal;
-    std::string targetNameImport;
-    std::string targetNamePDB;
-    std::string targetNameSO;
-
-    std::string targetOutput;
-    std::string targetOutputReal;
-    std::string targetOutputImplib;
-    std::string targetOutputDir;
-    std::string targetOutputPDBDir;
-    std::string targetOutputCompilePDBDir;
-  };
-
-  static void DetectOutput(FastbuildTargetNames& targetNamesOut,
-                           cmTarget& target, const std::string& configName)
-  {
-    if (target.GetType() == cmTarget::EXECUTABLE) {
-      target.GetExecutableNames(targetNamesOut.targetNameOut,
-                                targetNamesOut.targetNameReal,
-                                targetNamesOut.targetNameImport,
-                                targetNamesOut.targetNamePDB, configName);
-    } else {
-      target.GetLibraryNames(
-        targetNamesOut.targetNameOut, targetNamesOut.targetNameSO,
-        targetNamesOut.targetNameReal, targetNamesOut.targetNameImport,
-        targetNamesOut.targetNamePDB, configName);
-    }
-
-    if (target.HaveWellDefinedOutputFiles()) {
-      targetNamesOut.targetOutputDir = target.GetDirectory(configName) + "/";
-
-      targetNamesOut.targetOutput = target.GetFullPath(configName);
-      targetNamesOut.targetOutputReal = target.GetFullPath(configName,
-                                                           /*implib=*/false,
-                                                           /*realpath=*/true);
-      targetNamesOut.targetOutputImplib = target.GetFullPath(configName,
-                                                             /*implib=*/true);
-    } else {
-      targetNamesOut.targetOutputDir =
-        target.GetMakefile()->GetStartOutputDirectory();
-      if (targetNamesOut.targetOutputDir.empty() ||
-          targetNamesOut.targetOutputDir == ".") {
-        targetNamesOut.targetOutputDir = target.GetName();
-      } else {
-        targetNamesOut.targetOutputDir += "/";
-        targetNamesOut.targetOutputDir += target.GetName();
-      }
-      targetNamesOut.targetOutputDir += "/";
-      targetNamesOut.targetOutputDir += configName;
-      targetNamesOut.targetOutputDir += "/";
-
-      targetNamesOut.targetOutput =
-        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameOut;
-      targetNamesOut.targetOutputImplib =
-        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameImport;
-      targetNamesOut.targetOutputReal =
-        targetNamesOut.targetOutputDir + "/" + targetNamesOut.targetNameReal;
-    }
-
-    if (target.GetType() == cmTarget::EXECUTABLE ||
-        target.GetType() == cmTarget::STATIC_LIBRARY ||
-        target.GetType() == cmTarget::SHARED_LIBRARY ||
-        target.GetType() == cmTarget::MODULE_LIBRARY) {
-      targetNamesOut.targetOutputPDBDir = target.GetPDBDirectory(configName);
-      targetNamesOut.targetOutputPDBDir += "/";
-    }
-    if (target.GetType() <= cmTarget::OBJECT_LIBRARY) {
-      targetNamesOut.targetOutputCompilePDBDir =
-        target.GetCompilePDBPath(configName);
-      if (targetNamesOut.targetOutputCompilePDBDir.empty()) {
-        targetNamesOut.targetOutputCompilePDBDir =
-          target.GetSupportDirectory() + "/";
-      }
-    }
-
-    // Make sure all obey the correct slashes
-    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutput);
-    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputImplib);
-    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputReal);
-    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputDir);
-    cmSystemTools::ConvertToOutputSlashes(targetNamesOut.targetOutputPDBDir);
-    cmSystemTools::ConvertToOutputSlashes(
-      targetNamesOut.targetOutputCompilePDBDir);
-  }
-
-  static void ComputeLinkCmds(std::vector<std::string>& linkCmds,
-                              cmLocalFastbuildGenerator* lg, cmTarget& target,
-                              cmGeneratorTarget* gt, std::string configName)
-  {
-    const std::string& linkLanguage = target.GetLinkerLanguage(configName);
-    cmMakefile* mf = lg->GetMakefile();
-    {
-      std::string linkCmdVar =
-        gt->GetCreateRuleVariable(linkLanguage, configName);
-      const char* linkCmd = mf->GetDefinition(linkCmdVar);
-      if (linkCmd) {
-        cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
-        return;
-      }
-    }
-
-    // If the above failed, then lets try this:
-    switch (target.GetType()) {
-      case cmTarget::STATIC_LIBRARY: {
-        // We have archive link commands set. First, delete the existing
-        // archive.
-        {
-          std::string cmakeCommand = lg->ConvertToOutputFormat(
-            mf->GetRequiredDefinition("CMAKE_COMMAND"),
-            cmLocalGenerator::SHELL);
-          linkCmds.push_back(cmakeCommand + " -E remove $TARGET_FILE");
-        }
-        // TODO: Use ARCHIVE_APPEND for archives over a certain size.
-        {
-          std::string linkCmdVar = "CMAKE_";
-          linkCmdVar += linkLanguage;
-          linkCmdVar += "_ARCHIVE_CREATE";
-          const char* linkCmd = mf->GetRequiredDefinition(linkCmdVar);
-          cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
-        }
-        {
-          std::string linkCmdVar = "CMAKE_";
-          linkCmdVar += linkLanguage;
-          linkCmdVar += "_ARCHIVE_FINISH";
-          const char* linkCmd = mf->GetRequiredDefinition(linkCmdVar);
-          cmSystemTools::ExpandListArgument(linkCmd, linkCmds);
-        }
-        return;
-      }
-      case cmTarget::SHARED_LIBRARY:
-      case cmTarget::MODULE_LIBRARY:
-      case cmTarget::EXECUTABLE:
-        break;
-      default:
-        assert(0 && "Unexpected target type");
-    }
+//----------------------------------------------------------------------------
+void cmGlobalFastbuildGenerator::Detail::Detection::DetectLanguages(
+  std::set<std::string>& languages, const cmGeneratorTarget* generatorTarget)
+{
+  // Object libraries do not have linker stages
+  // nor utilities
+  bool hasObjectGroups = generatorTarget->GetType() != cmState::UTILITY &&
+    generatorTarget->GetType() != cmState::GLOBAL_TARGET;
+  if (!hasObjectGroups) {
     return;
   }
 
-  static std::string ComputeDefines(cmLocalFastbuildGenerator* lg,
-                                    cmTarget& target,
-                                    const cmSourceFile* source,
-                                    const std::string& configName,
-                                    const std::string& language)
-  {
-    std::set<std::string> defines;
+  std::vector<std::string> configs;
+  generatorTarget->Makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    const std::string& configName = *iter;
 
-    // Add the export symbol definition for shared library objects.
-    if (const char* exportMacro = target.GetExportMacro()) {
-      lg->AppendDefines(defines, exportMacro);
-    }
-
-    // Add preprocessor definitions for this target and configuration.
-    lg->AddCompileDefinitions(defines, &target, configName, language);
-
-    if (source) {
-      lg->AppendDefines(defines, source->GetProperty("COMPILE_DEFINITIONS"));
-
-      std::string defPropName = "COMPILE_DEFINITIONS_";
-      defPropName += cmSystemTools::UpperCase(configName);
-      lg->AppendDefines(defines, source->GetProperty(defPropName));
-    }
-
-    // Add a definition for the configuration name.
-    // NOTE: CMAKE_TEST_REQUIREMENT The following was added specifically to
-    // facillitate cmake testing. Doesn't feel right to do this...
-    std::string configDefine = "CMAKE_INTDIR=\"";
-    configDefine += configName;
-    configDefine += "\"";
-    lg->AppendDefines(defines, configDefine);
-
-    std::string definesString;
-    lg->JoinDefines(defines, definesString, language);
-
-    return definesString;
-  }
-
-  static void DetectLinkerLibPaths(std::string& linkerLibPath,
-                                   cmLocalFastbuildGenerator* lg,
-                                   cmTarget& target,
-                                   const std::string& configName)
-  {
-    cmMakefile* pMakefile = lg->GetMakefile();
-    cmComputeLinkInformation* pcli = target.GetLinkInformation(configName);
-    if (!pcli) {
-      // No link information, then no linker library paths
-      return;
-    }
-    cmComputeLinkInformation& cli = *pcli;
-
-    std::string libPathFlag =
-      pMakefile->GetRequiredDefinition("CMAKE_LIBRARY_PATH_FLAG");
-    std::string libPathTerminator =
-      pMakefile->GetSafeDefinition("CMAKE_LIBRARY_PATH_TERMINATOR");
-
-    // Append the library search path flags.
-    std::vector<std::string> const& libDirs = cli.GetDirectories();
-    for (std::vector<std::string>::const_iterator libDir = libDirs.begin();
-         libDir != libDirs.end(); ++libDir) {
-      std::string libpath = lg->ConvertToOutputForExisting(
-        *libDir, cmLocalGenerator::START_OUTPUT, cmLocalGenerator::SHELL);
-      cmSystemTools::ConvertToOutputSlashes(libpath);
-
-      // Add the linker lib path twice, once raw, then once with
-      // the configname attached
-      std::string configlibpath = libpath + "/" + configName;
-      cmSystemTools::ConvertToOutputSlashes(configlibpath);
-
-      linkerLibPath += " " + libPathFlag;
-      linkerLibPath += libpath;
-      linkerLibPath += libPathTerminator;
-
-      linkerLibPath += " " + libPathFlag;
-      linkerLibPath += configlibpath;
-      linkerLibPath += libPathTerminator;
-      linkerLibPath += " ";
-    }
-  }
-
-  static bool DetectBaseLinkerCommand(std::string& command,
-                                      cmLocalFastbuildGenerator* lg,
-                                      cmTarget& target, cmGeneratorTarget* gt,
-                                      const std::string& configName)
-  {
-    const std::string& linkLanguage = target.GetLinkerLanguage(configName);
-    if (linkLanguage.empty()) {
-      cmSystemTools::Error("CMake can not determine linker language for "
-                           "target: ",
-                           target.GetName().c_str());
-      return false;
-    }
-
-    cmLocalGenerator::RuleVariables vars;
-    vars.RuleLauncher = "RULE_LAUNCH_LINK";
-    vars.CMTarget = &target;
-    vars.Language = linkLanguage.c_str();
-
-    std::string responseFlag;
-    vars.Objects =
-      FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
-    vars.LinkLibraries = "";
-
-    vars.ObjectDir = FASTBUILD_DOLLAR_TAG "TargetOutDir" FASTBUILD_DOLLAR_TAG;
-    vars.Target =
-      FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
-
-    vars.TargetSOName =
-      FASTBUILD_DOLLAR_TAG "TargetOutSO" FASTBUILD_DOLLAR_TAG;
-    vars.TargetPDB = FASTBUILD_DOLLAR_TAG
-      "TargetOutPDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
-      "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
-
-    // Setup the target version.
-    std::string targetVersionMajor;
-    std::string targetVersionMinor;
-    {
-      std::ostringstream majorStream;
-      std::ostringstream minorStream;
-      int major;
-      int minor;
-      target.GetTargetVersion(major, minor);
-      majorStream << major;
-      minorStream << minor;
-      targetVersionMajor = majorStream.str();
-      targetVersionMinor = minorStream.str();
-    }
-    vars.TargetVersionMajor = targetVersionMajor.c_str();
-    vars.TargetVersionMinor = targetVersionMinor.c_str();
-
-    vars.Defines =
-      FASTBUILD_DOLLAR_TAG "CompileDefineFlags" FASTBUILD_DOLLAR_TAG;
-    vars.Flags = FASTBUILD_DOLLAR_TAG "TargetFlags" FASTBUILD_DOLLAR_TAG;
-    vars.LinkFlags = FASTBUILD_DOLLAR_TAG "LinkFlags" FASTBUILD_DOLLAR_TAG
-                                          " " FASTBUILD_DOLLAR_TAG
-                                          "LinkPath" FASTBUILD_DOLLAR_TAG;
-    // Rule for linking library/executable.
-    std::vector<std::string> linkCmds;
-    ComputeLinkCmds(linkCmds, lg, target, gt, configName);
-    for (std::vector<std::string>::iterator i = linkCmds.begin();
-         i != linkCmds.end(); ++i) {
-      lg->ExpandRuleVariables(*i, vars);
-    }
-
-    command = BuildCommandLine(linkCmds);
-
-    return true;
-  }
-
-  static void SplitExecutableAndFlags(const std::string& command,
-                                      std::string& executable,
-                                      std::string& options)
-  {
-    // Remove the command from the front
-    std::vector<std::string> args =
-      cmSystemTools::ParseArguments(command.c_str());
-
-    // Join the args together and remove 0 from the front
-    std::stringstream argSet;
-    std::copy(args.begin() + 1, args.end(),
-              std::ostream_iterator<std::string>(argSet, " "));
-
-    executable = args[0];
-    options = argSet.str();
-  }
-
-  static void DetectBaseCompileCommand(std::string& command,
-                                       cmLocalFastbuildGenerator* lg,
-                                       cmTarget& target,
-                                       const std::string& language)
-  {
-    cmLocalGenerator::RuleVariables compileObjectVars;
-    compileObjectVars.CMTarget = &target;
-    compileObjectVars.Language = language.c_str();
-    compileObjectVars.Source =
-      FASTBUILD_DOLLAR_TAG "FB_INPUT_1_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
-    compileObjectVars.Object =
-      FASTBUILD_DOLLAR_TAG "FB_INPUT_2_PLACEHOLDER" FASTBUILD_DOLLAR_TAG;
-    compileObjectVars.ObjectDir =
-      FASTBUILD_DOLLAR_TAG "TargetOutputDir" FASTBUILD_DOLLAR_TAG;
-    compileObjectVars.ObjectFileDir = "";
-    compileObjectVars.Flags = "";
-    compileObjectVars.Defines = "";
-    compileObjectVars.TargetCompilePDB = FASTBUILD_DOLLAR_TAG
-      "TargetOutCompilePDBDir" FASTBUILD_DOLLAR_TAG FASTBUILD_DOLLAR_TAG
-      "TargetNamePDB" FASTBUILD_DOLLAR_TAG;
-
-    // Rule for compiling object file.
-    std::string compileCmdVar = "CMAKE_";
-    compileCmdVar += language;
-    compileCmdVar += "_COMPILE_OBJECT";
-    std::string compileCmd =
-      lg->GetMakefile()->GetRequiredDefinition(compileCmdVar);
-    std::vector<std::string> compileCmds;
-    cmSystemTools::ExpandListArgument(compileCmd, compileCmds);
-
-    for (std::vector<std::string>::iterator i = compileCmds.begin();
-         i != compileCmds.end(); ++i) {
-      std::string& compileCmdStr = *i;
-      lg->ExpandRuleVariables(compileCmdStr, compileObjectVars);
-    }
-
-    command = BuildCommandLine(compileCmds);
-  }
-
-  static std::string DetectCompileRule(cmLocalFastbuildGenerator* lg,
-                                       cmTarget& target,
-                                       const std::string& lang)
-  {
-    cmLocalGenerator::RuleVariables vars;
-    vars.RuleLauncher = "RULE_LAUNCH_COMPILE";
-    vars.CMTarget = &target;
-    vars.Language = lang.c_str();
-    vars.Source = "$in";
-    vars.Object = "$out";
-    vars.Defines = "$DEFINES";
-    vars.TargetPDB = "$TARGET_PDB";
-    vars.TargetCompilePDB = "$TARGET_COMPILE_PDB";
-    vars.ObjectDir = "$OBJECT_DIR";
-    vars.ObjectFileDir = "$OBJECT_FILE_DIR";
-    vars.Flags = "$FLAGS";
-
-    cmMakefile* mf = lg->GetMakefile();
-
-    // Rule for compiling object file.
-    const std::string cmdVar =
-      std::string("CMAKE_") + lang + "_COMPILE_OBJECT";
-    std::string compileCmd = mf->GetRequiredDefinition(cmdVar);
-    std::vector<std::string> compileCmds;
-    cmSystemTools::ExpandListArgument(compileCmd, compileCmds);
-
-    for (std::vector<std::string>::iterator i = compileCmds.begin();
-         i != compileCmds.end(); ++i) {
-      std::string& compileCmdStr = *i;
-      lg->ExpandRuleVariables(compileCmdStr, vars);
-    }
-
-    std::string cmdLine = BuildCommandLine(compileCmds);
-
-    return cmdLine;
-  }
-
-  static void DetectLanguages(std::set<std::string>& languages,
-                              cmGlobalFastbuildGenerator* self,
-                              cmTarget& target)
-  {
-    // Object libraries do not have linker stages
-    // nor utilities
-    bool hasObjectGroups = target.GetType() != cmTarget::UTILITY &&
-      target.GetType() != cmTarget::GLOBAL_TARGET;
-    if (!hasObjectGroups) {
-      return;
-    }
-
-    cmGeneratorTarget* gt = self->GetGeneratorTarget(&target);
-
-    std::vector<std::string>::const_iterator iter = self->GetConfigurations()
-                                                      .begin(),
-                                             end =
-                                               self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
-      const std::string& configName = *iter;
-
-      std::vector<const cmSourceFile*> sourceFiles;
-      gt->GetObjectSources(sourceFiles, configName);
-      for (std::vector<const cmSourceFile*>::const_iterator i =
-             sourceFiles.begin();
-           i != sourceFiles.end(); ++i) {
-        const std::string& lang = (*i)->GetLanguage();
-        if (!lang.empty()) {
-          languages.insert(lang);
-        }
-      }
-    }
-  }
-
-  static void FilterSourceFiles(
-    std::vector<cmSourceFile const*>& filteredSourceFiles,
-    std::vector<cmSourceFile const*>& sourceFiles, const std::string& language)
-  {
-    for (std::vector<cmSourceFile const*>::const_iterator i =
+    std::vector<const cmSourceFile*> sourceFiles;
+    generatorTarget->GetObjectSources(sourceFiles, configName);
+    for (std::vector<const cmSourceFile*>::const_iterator i =
            sourceFiles.begin();
          i != sourceFiles.end(); ++i) {
-      const cmSourceFile* sf = *i;
-      if (sf->GetLanguage() == language) {
-        filteredSourceFiles.push_back(sf);
+      const std::string& lang = (*i)->GetLanguage();
+      if (!lang.empty()) {
+        languages.insert(lang);
       }
     }
   }
+}
 
-  static void DetectCompilerFlags(std::string& compileFlags,
-                                  cmLocalFastbuildGenerator* lg,
-                                  cmGeneratorTarget* gt, cmTarget& target,
-                                  const cmSourceFile* source,
-                                  const std::string& language,
-                                  const std::string& configName)
-  {
-    lg->AddLanguageFlags(compileFlags, language, configName);
+void cmGlobalFastbuildGenerator::Detail::Detection::FilterSourceFiles(
+  std::vector<cmSourceFile const*>& filteredSourceFiles,
+  std::vector<cmSourceFile const*>& sourceFiles, const std::string& language)
+{
+  for (std::vector<cmSourceFile const*>::const_iterator i =
+         sourceFiles.begin();
+       i != sourceFiles.end(); ++i) {
+    const cmSourceFile* sf = *i;
+    if (sf->GetLanguage() == language) {
+      filteredSourceFiles.push_back(sf);
+    }
+  }
+}
 
-    lg->AddArchitectureFlags(compileFlags, gt, language, configName);
+void cmGlobalFastbuildGenerator::Detail::Detection::DetectCompilerFlags(
+  std::string& compileFlags, cmLocalCommonGenerator* lg,
+  const cmGeneratorTarget* gt, const cmSourceFile* source,
+  const std::string& language, const std::string& configName)
+{
+  lg->AddLanguageFlags(compileFlags, language, configName);
 
-    // Add shared-library flags if needed.
-    lg->AddCMP0018Flags(compileFlags, &target, language, configName);
+  lg->AddArchitectureFlags(compileFlags, gt, language, configName);
 
-    lg->AddVisibilityPresetFlags(compileFlags, &target, language);
+  // Add shared-library flags if needed.
+  lg->AddCMP0018Flags(compileFlags, gt, language, configName);
 
-    std::vector<std::string> includes;
-    lg->GetIncludeDirectories(includes, gt, language, configName);
+  lg->AddVisibilityPresetFlags(compileFlags, gt, language);
 
-    // Add include directory flags.
-    std::string includeFlags = lg->GetIncludeFlags(
-      includes, gt, language,
-      language == "RC" ? true : false, // full include paths for RC
-      // needed by cmcldeps
-      false, configName);
+  std::vector<std::string> includes;
+  lg->GetIncludeDirectories(includes, gt, language, configName);
 
-    lg->AppendFlags(compileFlags, includeFlags);
+  // Add include directory flags.
+  // FIXME const cast are evil
+  std::string includeFlags = lg->GetIncludeFlags(
+    includes, (cmGeneratorTarget*)gt, language,
+    language == "RC" ? true : false, // full include paths for RC
+    // needed by cmcldeps
+    false, configName);
 
-    // Append old-style preprocessor definition flags.
-    lg->AppendFlags(compileFlags, lg->GetMakefile()->GetDefineFlags());
+  lg->AppendFlags(compileFlags, includeFlags);
 
-    // Add target-specific flags.
-    lg->AddCompileOptions(compileFlags, &target, language, configName);
+  // Append old-style preprocessor definition flags.
+  lg->AppendFlags(compileFlags, lg->GetMakefile()->GetDefineFlags());
 
-    if (source) {
-      lg->AppendFlags(compileFlags, source->GetProperty("COMPILE_FLAGS"));
+  // Add target-specific flags.
+  // FIXME const cast are evil
+  lg->AddCompileOptions(compileFlags, (cmGeneratorTarget*)gt, language,
+                        configName);
+
+  if (source) {
+    lg->AppendFlags(compileFlags, source->GetProperty("COMPILE_FLAGS"));
+  }
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
+  TargetHelper::GetOutputs(const cmGeneratorTarget* entry,
+                           std::vector<std::string>& outputs)
+{
+  outputs.push_back(entry->GetName());
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
+  TargetHelper::GetInputs(const cmGeneratorTarget* entry,
+                          std::vector<std::string>& inputs)
+{
+  TargetDependSet const& ts = gg->GetTargetDirectDepends(entry);
+  for (TargetDependSet::const_iterator iter = ts.begin(); iter != ts.end();
+       ++iter) {
+    const cmGeneratorTarget* dtarget = *iter;
+    inputs.push_back(dtarget->GetName());
+  }
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
+  CustomCommandHelper::GetOutputs(const cmSourceFile* entry,
+                                  std::vector<std::string>& outputs)
+{
+  const cmCustomCommand* cc = entry->GetCustomCommand();
+  cmMakefile* makefile = lg->GetMakefile();
+
+  // We need to generate the command for execution.
+  cmCustomCommandGenerator ccg(*cc, configName, lg);
+
+  const std::vector<std::string>& ccOutputs = ccg.GetOutputs();
+  const std::vector<std::string>& byproducts = ccg.GetByproducts();
+  outputs.insert(outputs.end(), ccOutputs.begin(), ccOutputs.end());
+  outputs.insert(outputs.end(), byproducts.begin(), byproducts.end());
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
+  CustomCommandHelper::GetInputs(const cmSourceFile* entry,
+                                 std::vector<std::string>& inputs)
+{
+  const cmCustomCommand* cc = entry->GetCustomCommand();
+  cmMakefile* makefile = lg->GetMakefile();
+  cmCustomCommandGenerator ccg(*cc, configName, lg);
+
+  std::string workingDirectory = ccg.GetWorkingDirectory();
+  if (workingDirectory.empty()) {
+    workingDirectory = makefile->GetCurrentBinaryDirectory();
+    workingDirectory += "/";
+  }
+
+  // Take the dependencies listed and split into targets and files.
+  const std::vector<std::string>& depends = ccg.GetDepends();
+  for (std::vector<std::string>::const_iterator iter = depends.begin();
+       iter != depends.end(); ++iter) {
+    std::string dep = *iter;
+
+    bool isTarget = gg->FindTarget(dep) != NULL;
+    if (!isTarget) {
+      if (!cmSystemTools::FileIsFullPath(dep.c_str())) {
+        dep = workingDirectory + dep;
+      }
+
+      inputs.push_back(dep);
+    }
+  }
+}
+
+void cmGlobalFastbuildGenerator::ComputeTargetOrderAndDependencies(
+  Detail::Detection::OrderedTargetSet& orderedTargets)
+{
+  TargetDependSet projectTargets;
+  TargetDependSet originalTargets;
+  std::map<std::string, std::vector<cmLocalGenerator *> >::const_iterator
+    it = this->GetProjectMap().begin(),
+    end = this->GetProjectMap().end();
+  for (; it != end; ++it) {
+    const std::vector<cmLocalGenerator*>& generators = it->second;
+    cmLocalFastbuildGenerator* root =
+      static_cast<cmLocalFastbuildGenerator*>(generators[0]);
+
+    // Given this information, calculate the dependencies:
+    // Collect all targets under this root generator and the transitive
+    // closure of their dependencies.
+
+    this->GetTargetSets(projectTargets, originalTargets, root, generators);
+  }
+
+  // Iterate over the targets and export their order
+  for (TargetDependSet::iterator iter = projectTargets.begin();
+       iter != projectTargets.end(); ++iter) {
+    const cmTargetDepend& targetDepend = *iter;
+    const cmGeneratorTarget* target = targetDepend.operator->();
+
+    orderedTargets.push_back(target);
+  }
+
+  Detail::Detection::DependencySorter::TargetHelper targetHelper = { this };
+  Detail::Detection::DependencySorter::Sort(targetHelper, orderedTargets);
+  Detail::Detection::StripNestedGlobalTargets(orderedTargets);
+}
+
+// Iterate over all targets and remove the ones that are
+// not needed for generation.
+// i.e. the nested global targets
+bool cmGlobalFastbuildGenerator::Detail::Detection::RemovalTest::operator()(
+  const cmGeneratorTarget* target) const
+{
+  if (target->GetType() == cmState::GLOBAL_TARGET) {
+    // We only want to process global targets that live in the home
+    // (i.e. top-level) directory.  CMake creates copies of these targets
+    // in every directory, which we don't need.
+    cmMakefile* mf = target->Target->GetMakefile();
+    if (strcmp(mf->GetCurrentSourceDirectory(), mf->GetHomeDirectory()) != 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::StripNestedGlobalTargets(
+  OrderedTargetSet& orderedTargets)
+{
+  orderedTargets.erase(std::remove_if(orderedTargets.begin(),
+                                      orderedTargets.end(), RemovalTest()),
+                       orderedTargets.end());
+}
+
+void cmGlobalFastbuildGenerator::Detail::Detection::DetectCompilerExtraFiles(
+  const std::string& compilerID, const std::string& version,
+  std::vector<std::string>& extraFiles)
+{
+  // Output a list of files that are relative to $CompilerRoot$
+  return;
+
+  if (compilerID == "MSVC") {
+    if (version.compare(0, 3, "18.") != std::string::npos) {
+      // Using vs2013
+      const char* vs2013_extraFiles[13] = {
+        "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
+        "$CompilerRoot$\\c1xx.dll", "$CompilerRoot$\\c1xxast.dll",
+        "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\msobj120.dll",
+        "$CompilerRoot$\\mspdb120.dll", "$CompilerRoot$\\mspdbcore.dll",
+        "$CompilerRoot$\\mspft120.dll", "$CompilerRoot$\\1033\\clui.dll",
+        "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcp120."
+        "dll",
+        "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcr120."
+        "dll",
+        "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120."
+        "CRT\\vccorlib120.dll"
+      };
+      extraFiles.insert(extraFiles.end(), &vs2013_extraFiles[0],
+                        &vs2013_extraFiles[13]);
+    } else if (version.compare(0, 3, "17.") != std::string::npos) {
+      // Using vs2012
+      const char* vs2012_extraFiles[12] = {
+        "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
+        "$CompilerRoot$\\c1xx.dll", "$CompilerRoot$\\c1xxast.dll",
+        "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\mspft110.dll",
+        "$CompilerRoot$\\1033\\clui.dll", "$CompilerRoot$\\..\\.."
+                                          "\\redist\\x86\\Microsoft.VC110."
+                                          "CRT\\msvcp110.dll",
+        "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110.CRT\\msvcr110."
+        "dll",
+        "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110."
+        "CRT\\vccorlib110.dll",
+        "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdb110.dll",
+        "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdbcore.dll"
+      };
+      extraFiles.insert(extraFiles.end(), &vs2012_extraFiles[0],
+                        &vs2012_extraFiles[12]);
+    }
+  }
+}
+
+//----------------------------------------------------------------------------
+
+std::string cmGlobalFastbuildGenerator::Quote(const std::string& str,
+                                              const std::string& quotation)
+{
+  std::string result = str;
+  cmSystemTools::ReplaceString(result, quotation, "^" + quotation);
+  return quotation + result + quotation;
+}
+
+std::string cmGlobalFastbuildGenerator::Detail::Generation::Join(
+  const std::vector<std::string>& elems, const std::string& delim)
+{
+  std::stringstream stringstream;
+  for (std::vector<std::string>::const_iterator iter = elems.begin();
+       iter != elems.end(); ++iter) {
+    stringstream << (*iter);
+    if (iter + 1 != elems.end()) {
+      stringstream << delim;
     }
   }
 
-  static void DetectTargetCompileDependencies(
-    cmGlobalFastbuildGenerator* gg, cmTarget& target,
-    std::vector<std::string>& dependencies)
-  {
-    if (target.GetType() == cmTarget::GLOBAL_TARGET) {
-      // Global targets only depend on other utilities, which may not appear in
-      // the TargetDepends set (e.g. "all").
-      std::set<std::string> const& utils = target.GetUtilities();
-      std::copy(utils.begin(), utils.end(), std::back_inserter(dependencies));
-    } else {
-      cmTargetDependSet const& targetDeps = gg->GetTargetDirectDepends(target);
-      for (cmTargetDependSet::const_iterator i = targetDeps.begin();
-           i != targetDeps.end(); ++i) {
-        const cmTargetDepend& depTarget = *i;
-        if (depTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
-          continue;
-        }
-        dependencies.push_back(depTarget->GetName());
-      }
-    }
-  }
+  return stringstream.str();
+}
 
-  static void DetectTargetLinkDependencies(
-    cmTarget& target, const std::string& configName,
-    std::vector<std::string>& dependencies)
-  {
-    // Static libraries never depend on other targets for linking.
-    if (target.GetType() == cmTarget::STATIC_LIBRARY ||
-        target.GetType() == cmTarget::OBJECT_LIBRARY) {
-      return;
-    }
+std::vector<std::string> cmGlobalFastbuildGenerator::Wrap(
+  const std::vector<std::string>& in, const std::string& prefix,
+  const std::string& suffix)
+{
+  std::vector<std::string> result;
 
-    cmComputeLinkInformation* cli = target.GetLinkInformation(configName);
-    if (!cli) {
-      return;
-    }
-
-    const std::vector<std::string>& deps = cli->GetDepends();
-    std::copy(deps.begin(), deps.end(), std::back_inserter(dependencies));
-  }
-
-  static std::string DetectTargetCompileOutputDir(
-    cmLocalFastbuildGenerator* lg, const cmTarget& target,
-    std::string configName)
-  {
-    std::string result = lg->GetTargetDirectory(target) + "/";
-    if (!configName.empty()) {
-      result = result + configName + "/";
-    }
-    cmSystemTools::ConvertToOutputSlashes(result);
-    return result;
-  }
-
-  static void DetectTargetObjectDependencies(
-    cmGlobalFastbuildGenerator* gg, cmTarget& target,
-    const std::string& configName, std::vector<std::string>& dependencies)
-  {
-    // Iterate over all source files and look for
-    // object file dependencies
-    cmGeneratorTarget* gt = gg->GetGeneratorTarget(&target);
-
-    std::set<std::string> objectLibs;
-
-    std::vector<cmSourceFile*> sourceFiles;
-    gt->GetSourceFiles(sourceFiles, configName);
-    for (std::vector<cmSourceFile*>::const_iterator i = sourceFiles.begin();
-         i != sourceFiles.end(); ++i) {
-      const std::string& objectLib = (*i)->GetObjectLibrary();
-      if (!objectLib.empty()) {
-        // Find the target this actually is (might be an alias)
-        const cmTarget* objectTarget = gg->FindTarget(objectLib);
-        if (objectTarget) {
-          objectLibs.insert(objectTarget->GetName() + "-" + configName +
-                            "-products");
-        }
-      }
-    }
-
-    std::copy(objectLibs.begin(), objectLibs.end(),
-              std::back_inserter(dependencies));
-
-    // Now add the external obj files that also need to be linked in
-    std::vector<const cmSourceFile*> objFiles;
-    gt->GetExternalObjects(objFiles, configName);
-    for (std::vector<const cmSourceFile*>::const_iterator i = objFiles.begin();
-         i != objFiles.end(); ++i) {
-      const cmSourceFile* sourceFile = *i;
-      if (sourceFile->GetObjectLibrary().empty()) {
-        dependencies.push_back(sourceFile->GetFullPath());
-      }
-    }
-  }
-
-  struct DependencySorter
-  {
-    struct TargetHelper
-    {
-      cmGlobalFastbuildGenerator* gg;
-
-      void GetOutputs(const cmTarget* entry, std::vector<std::string>& outputs)
-      {
-        outputs.push_back(entry->GetName());
-      }
-
-      void GetInputs(const cmTarget* entry, std::vector<std::string>& inputs)
-      {
-        TargetDependSet const& ts = gg->GetTargetDirectDepends(*entry);
-        for (TargetDependSet::const_iterator iter = ts.begin();
-             iter != ts.end(); ++iter) {
-          const cmTarget* dtarget = *iter;
-          inputs.push_back(dtarget->GetName());
-        }
-      }
-    };
-
-    struct CustomCommandHelper
-    {
-      cmGlobalFastbuildGenerator* gg;
-      cmLocalFastbuildGenerator* lg;
-      const std::string& configName;
-
-      void GetOutputs(const cmSourceFile* entry,
-                      std::vector<std::string>& outputs)
-      {
-        const cmCustomCommand* cc = entry->GetCustomCommand();
-        cmMakefile* makefile = lg->GetMakefile();
-
-        // We need to generate the command for execution.
-        cmCustomCommandGenerator ccg(*cc, configName, makefile);
-
-        const std::vector<std::string>& ccOutputs = ccg.GetOutputs();
-        const std::vector<std::string>& byproducts = ccg.GetByproducts();
-        outputs.insert(outputs.end(), ccOutputs.begin(), ccOutputs.end());
-        outputs.insert(outputs.end(), byproducts.begin(), byproducts.end());
-      }
-
-      void GetInputs(const cmSourceFile* entry,
-                     std::vector<std::string>& inputs)
-      {
-        const cmCustomCommand* cc = entry->GetCustomCommand();
-        cmMakefile* makefile = lg->GetMakefile();
-        cmCustomCommandGenerator ccg(*cc, configName, makefile);
-
-        std::string workingDirectory = ccg.GetWorkingDirectory();
-        if (workingDirectory.empty()) {
-          workingDirectory = makefile->GetCurrentOutputDirectory();
-          workingDirectory += "/";
-        }
-
-        // Take the dependencies listed and split into targets and files.
-        const std::vector<std::string>& depends = ccg.GetDepends();
-        for (std::vector<std::string>::const_iterator iter = depends.begin();
-             iter != depends.end(); ++iter) {
-          std::string dep = *iter;
-
-          bool isTarget = gg->FindTarget(dep) != NULL;
-          if (!isTarget) {
-            if (!cmSystemTools::FileIsFullPath(dep.c_str())) {
-              dep = workingDirectory + dep;
-            }
-
-            inputs.push_back(dep);
-          }
-        }
-      }
-    };
-
-    template <class TType, class TTypeHelper>
-    static void Sort(TTypeHelper& helper, std::vector<const TType*>& entries)
-    {
-      typedef std::vector<std::string> StringVector;
-      typedef std::vector<const TType*> OrderedEntrySet;
-      typedef std::map<std::string, const TType*> OutputMap;
-
-      // Build up a map of outputNames to entries
-      OutputMap outputMap;
-      for (typename OrderedEntrySet::iterator iter = entries.begin();
-           iter != entries.end(); ++iter) {
-        const TType* entry = *iter;
-        StringVector outputs;
-        helper.GetOutputs(entry, outputs);
-
-        for (StringVector::iterator outIter = outputs.begin();
-             outIter != outputs.end(); ++outIter) {
-          outputMap[*outIter] = entry;
-        }
-      }
-
-      // Now build a forward and reverse map of dependencies
-      // Build the reverse graph,
-      // each target, and the set of things that depend upon it
-      typedef std::map<const TType*, std::vector<const TType*> > DepMap;
-      DepMap forwardDeps;
-      DepMap reverseDeps;
-      for (typename OrderedEntrySet::iterator iter = entries.begin();
-           iter != entries.end(); ++iter) {
-        const TType* entry = *iter;
-        std::vector<const TType*>& entryInputs = forwardDeps[entry];
-
-        StringVector inputs;
-        helper.GetInputs(entry, inputs);
-        for (StringVector::const_iterator inIter = inputs.begin();
-             inIter != inputs.end(); ++inIter) {
-          const std::string& input = *inIter;
-          // Lookup the input in the output map and find the right entry
-          typename OutputMap::iterator findResult = outputMap.find(input);
-          if (findResult != outputMap.end()) {
-            const TType* dentry = findResult->second;
-            entryInputs.push_back(dentry);
-            reverseDeps[dentry].push_back(entry);
-          }
-        }
-      }
-
-      // We have all the information now.
-      // Clear the array passed in
-      entries.clear();
-
-      // Now iterate over each target with its list of dependencies.
-      // And dump out ones that have 0 dependencies.
-      bool written = true;
-      while (!forwardDeps.empty() && written) {
-        written = false;
-        for (typename DepMap::iterator iter = forwardDeps.begin();
-             iter != forwardDeps.end(); ++iter) {
-          std::vector<const TType*>& fwdDeps = iter->second;
-          const TType* entry = iter->first;
-          if (!fwdDeps.empty()) {
-            // Looking for empty dependency lists.
-            // Those are the next to be written out
-            continue;
-          }
-
-          // dependency list is empty,
-          // add it to the output list
-          written = true;
-          entries.push_back(entry);
-
-          // Use reverse dependencies to determine
-          // what forward dep lists to adjust
-          std::vector<const TType*>& revDeps = reverseDeps[entry];
-          for (unsigned int i = 0; i < revDeps.size(); ++i) {
-            const TType* revDep = revDeps[i];
-
-            // Fetch the list of deps on that target
-            std::vector<const TType*>& revDepFwdDeps = forwardDeps[revDep];
-            // remove the one we just added from the list
-            revDepFwdDeps.erase(
-              std::remove(revDepFwdDeps.begin(), revDepFwdDeps.end(), entry),
-              revDepFwdDeps.end());
-          }
-
-          // Remove it from forward deps so not
-          // considered again
-          forwardDeps.erase(entry);
-
-          // Must break now as we've invalidated
-          // our forward deps iterator
-          break;
-        }
-      }
-
-      // Validation...
-      // Make sure we managed to find a place
-      // to insert every dependency.
-      // If this fires, then there is most likely
-      // a cycle in the graph...
-      assert(forwardDeps.empty());
-    }
+  cmGlobalFastbuildGenerator::Detail::Generation::WrapHelper helper = {
+    prefix, suffix
   };
 
-  typedef std::vector<const cmTarget*> OrderedTargetSet;
-  static void ComputeTargetOrderAndDependencies(
-    cmGlobalFastbuildGenerator* gg, OrderedTargetSet& orderedTargets)
-  {
-    TargetDependSet projectTargets;
-    TargetDependSet originalTargets;
-    std::map<std::string, std::vector<cmLocalGenerator *> >::const_iterator
-      it = gg->GetProjectMap().begin(),
-      end = gg->GetProjectMap().end();
-    for (; it != end; ++it) {
-      const std::vector<cmLocalGenerator*>& generators = it->second;
-      cmLocalFastbuildGenerator* root =
-        static_cast<cmLocalFastbuildGenerator*>(generators[0]);
+  std::transform(in.begin(), in.end(), std::back_inserter(result), helper);
 
-      // Given this information, calculate the dependencies:
-      // Collect all targets under this root generator and the transitive
-      // closure of their dependencies.
+  return result;
+}
 
-      gg->GetTargetSets(projectTargets, originalTargets, root, generators);
+std::string cmGlobalFastbuildGenerator::Detail::Generation::EncodeLiteral(
+  const std::string& lit)
+{
+  std::string result = lit;
+  cmSystemTools::ReplaceString(result, "$", "^$");
+  return result;
+}
+
+void cmGlobalFastbuildGenerator::Detail::Generation::BuildTargetContexts(
+  cmGlobalFastbuildGenerator* gg, TargetContextList& map)
+{
+  std::map<std::string, std::vector<cmLocalGenerator *> >::const_iterator
+    it = gg->GetProjectMap().begin(),
+    end = gg->GetProjectMap().end();
+  for (; it != end; ++it) {
+    const std::vector<cmLocalGenerator*>& generators = it->second;
+    cmLocalFastbuildGenerator* root =
+      static_cast<cmLocalFastbuildGenerator*>(generators[0]);
+
+    // Build a map of all targets to their local generator
+    for (std::vector<cmLocalGenerator*>::const_iterator iter =
+           generators.begin();
+         iter != generators.end(); ++iter) {
+      cmLocalGenerator* lg = *iter;
+
+      if (gg->IsExcluded(root, lg)) {
+        continue;
+      }
+
+      for (std::vector<cmGeneratorTarget*>::const_iterator targetIter =
+             lg->GetGeneratorTargets().begin();
+           targetIter != lg->GetGeneratorTargets().end(); ++targetIter) {
+        cmGeneratorTarget* generatorTarget = *targetIter;
+        if (gg->IsRootOnlyTarget(generatorTarget) &&
+            lg->GetMakefile() != root->GetMakefile()) {
+          continue;
+        }
+        map.insert(generatorTarget);
+      }
+    }
+  }
+}
+
+void cmGlobalFastbuildGenerator::Detail::Generation::GenerateRootBFF(
+  cmGlobalFastbuildGenerator* self)
+{
+
+  cmLocalFastbuildGenerator* root =
+    static_cast<cmLocalFastbuildGenerator*>(self->GetLocalGenerators()[0]);
+
+  // Calculate filename
+  std::string fname = root->GetMakefile()->GetHomeOutputDirectory();
+  fname += "/fbuild.bff";
+
+  self->g_fc.setFileName(fname);
+  GenerationContext context(root, self->g_fc);
+  self->ComputeTargetOrderAndDependencies(context.orderedTargets);
+  BuildTargetContexts(self, context.targetContexts);
+  // write root bff
+  self->g_fc.WriteSectionHeader("Fastbuild makefile - Generated using CMAKE");
+
+  WritePlaceholders(self->g_fc);
+  WriteSettings(self->g_fc,
+                self->GetCMakeInstance()->GetHomeOutputDirectory());
+  WriteCompilers(context);
+  WriteConfigurations(self->g_fc, root->GetMakefile());
+
+  // Sort targets
+  WriteTargetDefinitions(context, false);
+  WriteAliases(context, self, false);
+  WriteTargetDefinitions(context, true);
+  WriteAliases(context, self, true);
+
+  self->g_fc.close();
+  self->FileReplacedDuringGenerate(fname);
+}
+
+void cmGlobalFastbuildGenerator::Detail::Generation::WritePlaceholders(
+  FileContext& fileContext)
+{
+  // Define some placeholder
+  fileContext.WriteSectionHeader("Helper variables");
+
+  fileContext.WriteVariable("FB_INPUT_1_PLACEHOLDER", Quote("\"%1\""));
+  fileContext.WriteVariable("FB_INPUT_2_PLACEHOLDER", Quote("\"%2\""));
+}
+
+void cmGlobalFastbuildGenerator::Detail::Generation::WriteSettings(
+  FileContext& fileContext, std::string cacheDir)
+{
+  fileContext.WriteSectionHeader("Settings");
+
+  fileContext.WriteCommand("Settings");
+  fileContext.WritePushScope();
+
+  cacheDir += "\\.fbuild.cache";
+  cmSystemTools::ConvertToOutputSlashes(cacheDir);
+
+  fileContext.WriteVariable("CachePath", Quote(cacheDir));
+  fileContext.WritePopScope();
+}
+
+bool cmGlobalFastbuildGenerator::Detail::Generation::WriteCompilers(
+  GenerationContext& context)
+{
+  cmMakefile* mf = context.root->GetMakefile();
+
+  context.fc.WriteSectionHeader("Compilers");
+
+  // Detect each language used in the definitions
+  std::set<std::string> languages;
+  for (TargetContextList::iterator iter = context.targetContexts.begin();
+       iter != context.targetContexts.end(); ++iter) {
+
+    if ((*iter)->GetType() == cmState::INTERFACE_LIBRARY) {
+      continue;
     }
 
-    // Iterate over the targets and export their order
-    for (TargetDependSet::iterator iter = projectTargets.begin();
-         iter != projectTargets.end(); ++iter) {
-      const cmTargetDepend& targetDepend = *iter;
-      const cmTarget& target = *targetDepend;
-
-      orderedTargets.push_back(&target);
-    }
-
-    DependencySorter::TargetHelper targetHelper = { gg };
-    DependencySorter::Sort(targetHelper, orderedTargets);
+    Detection::DetectLanguages(languages, *iter);
   }
 
-  // Iterate over all targets and remove the ones that are
-  // not needed for generation.
-  // i.e. the nested global targets
-  struct RemovalTest
-  {
-    bool operator()(const cmTarget* target) const
-    {
-      if (target->GetType() == cmTarget::GLOBAL_TARGET) {
-        // We only want to process global targets that live in the home
-        // (i.e. top-level) directory.  CMake creates copies of these targets
-        // in every directory, which we don't need.
-        cmMakefile* mf = target->GetMakefile();
-        if (strcmp(mf->GetStartDirectory(), mf->GetHomeDirectory()) != 0) {
-          return true;
-        }
-      }
+  // Now output a compiler for each of these languages
+  typedef std::map<std::string, std::string> StringMap;
+  typedef std::map<std::string, CompilerDef> CompilerDefMap;
+  CompilerDefMap compilerToDef;
+  StringMap languageToCompiler;
+  for (std::set<std::string>::iterator iter = languages.begin();
+       iter != languages.end(); ++iter) {
+    const std::string& language = *iter;
+
+    // Calculate the root location of the compiler
+    std::string variableString = "CMAKE_" + language + "_COMPILER";
+    std::string compilerLocation = mf->GetSafeDefinition(variableString);
+    if (compilerLocation.empty()) {
       return false;
     }
-  };
 
-  static void StripNestedGlobalTargets(OrderedTargetSet& orderedTargets)
-  {
-    orderedTargets.erase(std::remove_if(orderedTargets.begin(),
-                                        orderedTargets.end(), RemovalTest()),
-                         orderedTargets.end());
+    // Add the language to the compiler's name
+    CompilerDef& compilerDef = compilerToDef[compilerLocation];
+    if (compilerDef.name.empty()) {
+      compilerDef.name = "Compiler";
+      compilerDef.path = compilerLocation;
+      compilerDef.cmakeCompilerID =
+        mf->GetSafeDefinition("CMAKE_" + language + "_COMPILER_ID");
+      compilerDef.cmakeCompilerVersion =
+        mf->GetSafeDefinition("CMAKE_" + language + "_COMPILER_VERSION");
+    }
+    compilerDef.name += "-";
+    compilerDef.name += language;
+
+    // Now add the language to point to that compiler location
+    languageToCompiler[language] = compilerLocation;
   }
 
-  static bool isConfigDependant(const cmCustomCommandGenerator& ccg)
-  {
-    typedef std::vector<std::string> StringVector;
-    StringVector outputs = ccg.GetOutputs();
-    StringVector byproducts = ccg.GetByproducts();
+  // Now output all the compilers
+  for (CompilerDefMap::iterator iter = compilerToDef.begin();
+       iter != compilerToDef.end(); ++iter) {
+    const CompilerDef& compilerDef = iter->second;
 
-    std::for_each(outputs.begin(), outputs.end(),
-                  &Detection::UnescapeFastbuildVariables);
-    std::for_each(byproducts.begin(), byproducts.end(),
-                  &Detection::UnescapeFastbuildVariables);
+    // Detect the list of extra files used by this compiler
+    // for distribution
+    std::vector<std::string> extraFiles;
+    Detection::DetectCompilerExtraFiles(compilerDef.cmakeCompilerID,
+                                        compilerDef.cmakeCompilerVersion,
+                                        extraFiles);
 
-    // Make sure that the outputs don't depend on the config name
-    for (StringVector::const_iterator iter = outputs.begin();
-         iter != outputs.end(); ++iter) {
-      const std::string& str = *iter;
-      if (str.find("$ConfigName$") != std::string::npos) {
-        return true;
-      }
-    }
-    for (StringVector::const_iterator iter = byproducts.begin();
-         iter != byproducts.end(); ++iter) {
-      const std::string& str = *iter;
-      if (str.find("$ConfigName$") != std::string::npos) {
-        return true;
-      }
-    }
+    // Strip out the path to the compiler
+    std::string compilerPath =
+      cmSystemTools::GetFilenamePath(compilerDef.path);
+    std::string compilerFile =
+      "$CompilerRoot$\\" + cmSystemTools::GetFilenameName(compilerDef.path);
 
-    return false;
+    cmSystemTools::ConvertToOutputSlashes(compilerPath);
+    cmSystemTools::ConvertToOutputSlashes(compilerFile);
+
+    // Write out the compiler that has been configured
+    context.fc.WriteCommand("Compiler", Quote(compilerDef.name));
+    context.fc.WritePushScope();
+    context.fc.WriteVariable("CompilerRoot", Quote(compilerPath));
+    context.fc.WriteVariable("Executable", Quote(compilerFile));
+    context.fc.WriteArray("ExtraFiles", Wrap(extraFiles));
+
+    context.fc.WritePopScope();
   }
 
-  static void DetectCompilerExtraFiles(const std::string& compilerID,
-                                       const std::string& version,
-                                       std::vector<std::string>& extraFiles)
-  {
-    // Output a list of files that are relative to $CompilerRoot$
-    return;
+  // Now output the compiler names according to language as variables
+  for (StringMap::iterator iter = languageToCompiler.begin();
+       iter != languageToCompiler.end(); ++iter) {
+    const std::string& language = iter->first;
+    const std::string& compilerLocation = iter->second;
+    const CompilerDef& compilerDef = compilerToDef[compilerLocation];
 
-    if (compilerID == "MSVC") {
-      if (version.compare(0, 3, "18.") != std::string::npos) {
-        // Using vs2013
-        const char* vs2013_extraFiles[13] = {
-          "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
-          "$CompilerRoot$\\c1xx.dll", "$CompilerRoot$\\c1xxast.dll",
-          "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\msobj120.dll",
-          "$CompilerRoot$\\mspdb120.dll", "$CompilerRoot$\\mspdbcore.dll",
-          "$CompilerRoot$\\mspft120.dll", "$CompilerRoot$\\1033\\clui.dll",
-          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcp120."
-          "dll",
-          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120.CRT\\msvcr120."
-          "dll",
-          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC120."
-          "CRT\\vccorlib120.dll"
-        };
-        extraFiles.insert(extraFiles.end(), &vs2013_extraFiles[0],
-                          &vs2013_extraFiles[13]);
-      } else if (version.compare(0, 3, "17.") != std::string::npos) {
-        // Using vs2012
-        const char* vs2012_extraFiles[12] = {
-          "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
-          "$CompilerRoot$\\c1xx.dll", "$CompilerRoot$\\c1xxast.dll",
-          "$CompilerRoot$\\c2.dll", "$CompilerRoot$\\mspft110.dll",
-          "$CompilerRoot$\\1033\\clui.dll", "$CompilerRoot$\\..\\.."
-                                            "\\redist\\x86\\Microsoft.VC110."
-                                            "CRT\\msvcp110.dll",
-          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110.CRT\\msvcr110."
-          "dll",
-          "$CompilerRoot$\\..\\..\\redist\\x86\\Microsoft.VC110."
-          "CRT\\vccorlib110.dll",
-          "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdb110.dll",
-          "$CompilerRoot$\\..\\..\\..\\Common7\\IDE\\mspdbcore.dll"
-        };
-        extraFiles.insert(extraFiles.end(), &vs2012_extraFiles[0],
-                          &vs2012_extraFiles[12]);
-      }
+    // Output a default compiler to absorb the library requirements for a
+    // compiler
+    if (iter == languageToCompiler.begin()) {
+      context.fc.WriteVariable("Compiler_dummy", Quote(compilerDef.name));
     }
+
+    context.fc.WriteVariable("Compiler_" + language, Quote(compilerDef.name));
   }
 
-private:
-};
+  return true;
+}
 
-//----------------------------------------------------------------------------
-class cmGlobalFastbuildGenerator::Detail::Definition
+void cmGlobalFastbuildGenerator::Detail::Generation::WriteConfigurations(
+  FileContext& fileContext, cmMakefile* makefile)
 {
-  struct FastbuildSettings
-  {
-    std::string cachePath;
-  };
+  fileContext.WriteSectionHeader("Configurations");
 
-  struct FastbuildCompiler
-  {
-    std::string executable;
-  };
-  typedef std::map<std::string, FastbuildCompiler> CompilerMap;
+  fileContext.WriteVariable("ConfigBase", "");
+  fileContext.WritePushScopeStruct();
+  fileContext.WritePopScope();
 
-  struct FastbuildConfiguration
-  {
-    std::string name;
-  };
-  typedef std::map<std::string, FastbuildConfiguration> ConfigurationMap;
+  // Iterate over all configurations and define them:
+  std::vector<std::string> configs;
+  makefile->GetConfigurations(configs, false);
+  for (std::vector<std::string>::const_iterator iter = configs.begin();
+       iter != configs.end(); ++iter) {
+    const std::string& configName = *iter;
+    fileContext.WriteVariable("config_" + configName, "");
+    fileContext.WritePushScopeStruct();
 
-  struct FastbuildStructure
-  {
-    ConfigurationMap configurations;
+    // Using base config
+    fileContext.WriteCommand("Using", ".ConfigBase");
 
-    FastbuildSettings settings;
-    CompilerMap compilers;
-  };
-};
+    fileContext.WritePopScope();
+  }
 
-//----------------------------------------------------------------------------
-class cmGlobalFastbuildGenerator::Detail::Generation
+  // Write out a list of all configs
+  fileContext.WriteArray("all_configs", Wrap(configs, ".config_", ""));
+}
+
+void cmGlobalFastbuildGenerator::Detail::Generation::WriteTargetDefinitions(
+  GenerationContext& context, bool outputGlobals)
 {
-public:
-  struct TargetGenerationContext
-  {
-    cmTarget* target;
-    cmLocalFastbuildGenerator* root;
-    std::vector<cmLocalGenerator*> generators;
-    cmLocalFastbuildGenerator* lg;
-  };
-  typedef std::map<const cmTarget*, TargetGenerationContext> TargetContextMap;
-  typedef std::map<const cmCustomCommand*, std::set<std::string> >
-    CustomCommandAliasMap;
-  typedef Detection::OrderedTargetSet OrderedTargets;
+  context.fc.WriteSectionHeader((outputGlobals) ? "Global Target Definitions"
+                                                : "Target Definitions");
 
-  struct GenerationContext
-  {
-    GenerationContext(cmGlobalFastbuildGenerator* globalGen,
-                      cmLocalFastbuildGenerator* localGen,
-                      FileContext& fileCtx)
-      : self(globalGen)
-      , root(localGen)
-      , fc(fileCtx)
-    {
+  // Now iterate each target in order
+  for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
+       targetIter != context.orderedTargets.end(); ++targetIter) {
+    const cmGeneratorTarget* constTarget = (*targetIter);
+    if (constTarget->GetType() == cmState::INTERFACE_LIBRARY) {
+      continue;
     }
-    cmGlobalFastbuildGenerator* self;
-    cmLocalFastbuildGenerator* root;
-    FileContext& fc;
-    OrderedTargets orderedTargets;
-    TargetContextMap targetContexts;
-    CustomCommandAliasMap customCommandAliases;
-  };
+    // FIXME const cast are evil
+    cmGeneratorTarget* target = (cmGeneratorTarget*)constTarget;
 
-  static std::string Quote(const std::string& str,
-                           const std::string& quotation = "'")
-  {
-    std::string result = str;
-    cmSystemTools::ReplaceString(result, quotation, "^" + quotation);
-    return quotation + result + quotation;
-  }
-
-  static std::string Join(const std::vector<std::string>& elems,
-                          const std::string& delim)
-  {
-    std::stringstream stringstream;
-    for (std::vector<std::string>::const_iterator iter = elems.begin();
-         iter != elems.end(); ++iter) {
-      stringstream << (*iter);
-      if (iter + 1 != elems.end()) {
-        stringstream << delim;
-      }
-    }
-
-    return stringstream.str();
-  }
-
-  struct WrapHelper
-  {
-    std::string m_prefix;
-    std::string m_suffix;
-
-    std::string operator()(const std::string& in)
-    {
-      return m_prefix + in + m_suffix;
-    }
-  };
-
-  static std::vector<std::string> Wrap(const std::vector<std::string>& in,
-                                       const std::string& prefix = "'",
-                                       const std::string& suffix = "'")
-  {
-    std::vector<std::string> result;
-
-    WrapHelper helper = { prefix, suffix };
-
-    std::transform(in.begin(), in.end(), std::back_inserter(result), helper);
-
-    return result;
-  }
-
-  static std::string EncodeLiteral(const std::string& lit)
-  {
-    std::string result = lit;
-    cmSystemTools::ReplaceString(result, "$", "^$");
-    return result;
-  }
-
-  static void EnsureDirectoryExists(const std::string& path,
-                                    GenerationContext& context)
-  {
-    if (cmSystemTools::FileIsFullPath(path.c_str())) {
-      cmSystemTools::MakeDirectory(path.c_str());
+    if (target->GetType() == cmState::GLOBAL_TARGET) {
+      if (!outputGlobals)
+        continue;
     } else {
-      const std::string fullPath =
-        std::string(
-          context.self->GetCMakeInstance()->GetHomeOutputDirectory()) +
-        "/" + path;
-      cmSystemTools::MakeDirectory(fullPath.c_str());
-    }
-  }
-
-  static void BuildTargetContexts(cmGlobalFastbuildGenerator* gg,
-                                  TargetContextMap& map)
-  {
-    std::map<std::string, std::vector<cmLocalGenerator *> >::const_iterator
-      it = gg->GetProjectMap().begin(),
-      end = gg->GetProjectMap().end();
-    for (; it != end; ++it) {
-      const std::vector<cmLocalGenerator*>& generators = it->second;
-      cmLocalFastbuildGenerator* root =
-        static_cast<cmLocalFastbuildGenerator*>(generators[0]);
-
-      // Build a map of all targets to their local generator
-      for (std::vector<cmLocalGenerator*>::const_iterator iter =
-             generators.begin();
-           iter != generators.end(); ++iter) {
-        cmLocalFastbuildGenerator* lg =
-          static_cast<cmLocalFastbuildGenerator*>(*iter);
-
-        if (gg->IsExcluded(root, lg)) {
-          continue;
-        }
-
-        cmTargets& tgts = lg->GetMakefile()->GetTargets();
-        for (cmTargets::iterator targetIter = tgts.begin();
-             targetIter != tgts.end(); ++targetIter) {
-          cmTarget& target = (targetIter->second);
-
-          if (gg->IsRootOnlyTarget(&target) &&
-              target.GetMakefile() != root->GetMakefile()) {
-            continue;
-          }
-
-          TargetGenerationContext targetContext = { &target, root, generators,
-                                                    lg };
-          map[&target] = targetContext;
-        }
-      }
-    }
-  }
-
-  static void GenerateRootBFF(cmGlobalFastbuildGenerator* self)
-  {
-
-    cmLocalFastbuildGenerator* root =
-      static_cast<cmLocalFastbuildGenerator*>(self->GetLocalGenerators()[0]);
-
-    // Calculate filename
-    std::string fname = root->GetMakefile()->GetStartOutputDirectory();
-    fname += "/";
-    // fname += root->GetMakefile()->GetProjectName();
-    fname += "fbuild";
-    fname += ".bff";
-
-    // Open file
-    cmGeneratedFileStream fout(fname.c_str());
-    fout.SetCopyIfDifferent(true);
-    if (!fout) {
-      return;
-    }
-
-    FileContext fc(fout);
-    GenerationContext context(self, root, fc);
-    Detection::ComputeTargetOrderAndDependencies(context.self,
-                                                 context.orderedTargets);
-    Detection::StripNestedGlobalTargets(context.orderedTargets);
-    BuildTargetContexts(context.self, context.targetContexts);
-    WriteRootBFF(context);
-
-    // Close file
-    if (fout.Close()) {
-      self->FileReplacedDuringGenerate(fname);
-    }
-  }
-
-  static void WriteRootBFF(GenerationContext& context)
-  {
-    context.fc.WriteSectionHeader(
-      "Fastbuild makefile - Generated using CMAKE");
-
-    WritePlaceholders(context);
-    WriteSettings(context);
-    WriteCompilers(context);
-    WriteConfigurations(context);
-
-    // Sort targets
-
-    WriteTargetDefinitions(context, false);
-    WriteAliases(context, false);
-    WriteTargetDefinitions(context, true);
-    WriteAliases(context, true);
-  }
-
-  static void WritePlaceholders(GenerationContext& context)
-  {
-    // Define some placeholder
-    context.fc.WriteSectionHeader("Helper variables");
-
-    context.fc.WriteVariable("FB_INPUT_1_PLACEHOLDER", Quote("\"%1\""));
-    context.fc.WriteVariable("FB_INPUT_2_PLACEHOLDER", Quote("\"%2\""));
-  }
-
-  static void WriteSettings(GenerationContext& context)
-  {
-    context.fc.WriteSectionHeader("Settings");
-
-    context.fc.WriteCommand("Settings");
-    context.fc.WritePushScope();
-
-    std::string cacheDir =
-      context.self->GetCMakeInstance()->GetHomeOutputDirectory();
-    cacheDir += "\\.fbuild.cache";
-    cmSystemTools::ConvertToOutputSlashes(cacheDir);
-
-    context.fc.WriteVariable("CachePath", Quote(cacheDir));
-    context.fc.WritePopScope();
-  }
-
-  struct CompilerDef
-  {
-    std::string name;
-    std::string path;
-    std::string cmakeCompilerID;
-    std::string cmakeCompilerVersion;
-  };
-
-  static bool WriteCompilers(GenerationContext& context)
-  {
-    cmMakefile* mf = context.root->GetMakefile();
-
-    context.fc.WriteSectionHeader("Compilers");
-
-    // Detect each language used in the definitions
-    std::set<std::string> languages;
-    for (TargetContextMap::iterator iter = context.targetContexts.begin();
-         iter != context.targetContexts.end(); ++iter) {
-      TargetGenerationContext& targetContext = iter->second;
-
-      if (targetContext.target->GetType() == cmTarget::INTERFACE_LIBRARY) {
+      if (outputGlobals)
         continue;
-      }
-
-      Detection::DetectLanguages(languages, context.self,
-                                 *targetContext.target);
     }
 
-    // Now output a compiler for each of these languages
-    typedef std::map<std::string, std::string> StringMap;
-    typedef std::map<std::string, CompilerDef> CompilerDefMap;
-    CompilerDefMap compilerToDef;
-    StringMap languageToCompiler;
-    for (std::set<std::string>::iterator iter = languages.begin();
-         iter != languages.end(); ++iter) {
-      const std::string& language = *iter;
-
-      // Calculate the root location of the compiler
-      std::string variableString = "CMAKE_" + language + "_COMPILER";
-      std::string compilerLocation = mf->GetSafeDefinition(variableString);
-      if (compilerLocation.empty()) {
-        return false;
+    switch (target->GetType()) {
+      case cmState::EXECUTABLE:
+      case cmState::SHARED_LIBRARY:
+      case cmState::STATIC_LIBRARY:
+      case cmState::MODULE_LIBRARY:
+      case cmState::OBJECT_LIBRARY:
+      // TODO should utility target be treated differently ?
+      case cmState::UTILITY:
+      case cmState::GLOBAL_TARGET: {
+        cmFastbuildTargetGenerator targetGenerator(target);
+        targetGenerator.Generate();
+        break;
       }
 
-      // Add the language to the compiler's name
-      CompilerDef& compilerDef = compilerToDef[compilerLocation];
-      if (compilerDef.name.empty()) {
-        compilerDef.name = "Compiler";
-        compilerDef.path = compilerLocation;
-        compilerDef.cmakeCompilerID =
-          mf->GetSafeDefinition("CMAKE_" + language + "_COMPILER_ID");
-        compilerDef.cmakeCompilerVersion =
-          mf->GetSafeDefinition("CMAKE_" + language + "_COMPILER_VERSION");
-      }
-      compilerDef.name += "-";
-      compilerDef.name += language;
-
-      // Now add the language to point to that compiler location
-      languageToCompiler[language] = compilerLocation;
+      break;
+      default:
+        break;
     }
-
-    // Now output all the compilers
-    for (CompilerDefMap::iterator iter = compilerToDef.begin();
-         iter != compilerToDef.end(); ++iter) {
-      const CompilerDef& compilerDef = iter->second;
-
-      // Detect the list of extra files used by this compiler
-      // for distribution
-      std::vector<std::string> extraFiles;
-      Detection::DetectCompilerExtraFiles(compilerDef.cmakeCompilerID,
-                                          compilerDef.cmakeCompilerVersion,
-                                          extraFiles);
-
-      // Strip out the path to the compiler
-      std::string compilerPath =
-        cmSystemTools::GetFilenamePath(compilerDef.path);
-      std::string compilerFile =
-        "$CompilerRoot$\\" + cmSystemTools::GetFilenameName(compilerDef.path);
-
-      cmSystemTools::ConvertToOutputSlashes(compilerPath);
-      cmSystemTools::ConvertToOutputSlashes(compilerFile);
-
-      // Write out the compiler that has been configured
-      context.fc.WriteCommand("Compiler", Quote(compilerDef.name));
-      context.fc.WritePushScope();
-      context.fc.WriteVariable("CompilerRoot", Quote(compilerPath));
-      context.fc.WriteVariable("Executable", Quote(compilerFile));
-      context.fc.WriteArray("ExtraFiles", Wrap(extraFiles));
-
-      context.fc.WritePopScope();
-    }
-
-    // Now output the compiler names according to language as variables
-    for (StringMap::iterator iter = languageToCompiler.begin();
-         iter != languageToCompiler.end(); ++iter) {
-      const std::string& language = iter->first;
-      const std::string& compilerLocation = iter->second;
-      const CompilerDef& compilerDef = compilerToDef[compilerLocation];
-
-      // Output a default compiler to absorb the library requirements for a
-      // compiler
-      if (iter == languageToCompiler.begin()) {
-        context.fc.WriteVariable("Compiler_dummy", Quote(compilerDef.name));
-      }
-
-      context.fc.WriteVariable("Compiler_" + language,
-                               Quote(compilerDef.name));
-    }
-
-    return true;
   }
+}
 
-  static void WriteConfigurations(GenerationContext& context)
-  {
-    context.fc.WriteSectionHeader("Configurations");
+void cmGlobalFastbuildGenerator::Detail::Generation::WriteAliases(
+  GenerationContext& context, cmGlobalFastbuildGenerator* gg,
+  bool outputGlobals)
+{
+  context.fc.WriteSectionHeader("Aliases");
 
-    context.fc.WriteVariable("ConfigBase", "");
-    context.fc.WritePushScopeStruct();
-    context.fc.WritePopScope();
+  // Write the following aliases:
+  // Per Target
+  // Per Config
+  // All
 
-    // Iterate over all configurations and define them:
-    std::vector<std::string>::const_iterator
-      iter = context.self->GetConfigurations().begin(),
-      end = context.self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
-      const std::string& configName = *iter;
-      context.fc.WriteVariable("config_" + configName, "");
-      context.fc.WritePushScopeStruct();
+  typedef std::map<std::string, std::vector<std::string> > TargetListMap;
+  TargetListMap perConfig;
+  TargetListMap perTarget;
 
-      // Using base config
-      context.fc.WriteCommand("Using", ".ConfigBase");
-
-      context.fc.WritePopScope();
+  for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
+       targetIter != context.orderedTargets.end(); ++targetIter) {
+    const cmGeneratorTarget* constTarget = (*targetIter);
+    if (constTarget->GetType() == cmState::INTERFACE_LIBRARY) {
+      continue;
     }
 
-    // Write out a list of all configs
-    context.fc.WriteArray(
-      "all_configs", Wrap(context.self->GetConfigurations(), ".config_", ""));
-  }
-
-  static void WriteCustomCommand(GenerationContext& context,
-                                 const cmCustomCommand* cc,
-                                 cmLocalFastbuildGenerator* lg,
-                                 cmTarget& target,
-                                 const std::string& configName,
-                                 std::string& targetName,
-                                 const std::string& hostTargetName)
-  {
-    cmMakefile* makefile = lg->GetMakefile();
-
-    // We need to generate the command for execution.
-    cmCustomCommandGenerator ccg(*cc, configName, makefile);
-
-    const std::vector<std::string>& outputs = ccg.GetOutputs();
-    const std::vector<std::string>& byproducts = ccg.GetByproducts();
-    std::vector<std::string> mergedOutputs;
-    mergedOutputs.insert(mergedOutputs.end(), outputs.begin(), outputs.end());
-    mergedOutputs.insert(mergedOutputs.end(), byproducts.begin(),
-                         byproducts.end());
-
-    // TODO: Double check that none of the outputs are 'symbolic'
-    // In which case, FASTBuild won't want them treated as
-    // outputs.
-    {
-      // Loop through all outputs, and attempt to find it in the
-      // source files.
-      for (size_t index = 0; index < mergedOutputs.size(); ++index) {
-        const std::string& outputName = mergedOutputs[index];
-
-        cmSourceFile* outputSourceFile = makefile->GetSource(outputName);
-        // Check if this file is symbolic
-        if (outputSourceFile &&
-            outputSourceFile->GetPropertyAsBool("SYMBOLIC")) {
-          // We need to remove this file from the list of outputs
-          // Swap with back and pop
-          mergedOutputs[index] = mergedOutputs.back();
-          mergedOutputs.pop_back();
-        }
-      }
+    // FIXME const cast are evil
+    TargetContextList::iterator findResult =
+      context.targetContexts.find((cmGeneratorTarget*)constTarget);
+    if (findResult == context.targetContexts.end()) {
+      continue;
     }
 
-    std::vector<std::string> inputs;
-    std::vector<std::string> orderDependencies;
+    cmGeneratorTarget* target = *findResult;
+    const std::string& targetName = target->GetName();
 
-    // If this exec node always generates outputs,
-    // then we need to make sure we don't define outputs multiple times.
-    // but if the command should always run (i.e. post builds etc)
-    // then we will output a new one.
-    if (!mergedOutputs.empty()) {
-      // Check if this custom command has already been output.
-      // If it has then just drop an alias here to the original
-      CustomCommandAliasMap::iterator findResult =
-        context.customCommandAliases.find(cc);
-      if (findResult != context.customCommandAliases.end()) {
-        const std::set<std::string>& aliases = findResult->second;
-        if (aliases.find(targetName) != aliases.end()) {
-          // This target has already been generated
-          // with the correct name somewhere else.
-          return;
-        }
-        if (!Detection::isConfigDependant(ccg)) {
-          // This command has already been generated.
-          // But under a different name so setup an alias to redirect
-          // No merged outputs, so this command must always be run.
-          // Make it's name unique to its host target
-          targetName += "-";
-          targetName += hostTargetName;
-
-          std::vector<std::string> targets;
-          targets.push_back(*findResult->second.begin());
-
-          context.fc.WriteCommand("Alias", Quote(targetName));
-          context.fc.WritePushScope();
-          {
-            context.fc.WriteArray("Targets", Wrap(targets));
-          }
-          context.fc.WritePopScope();
-          return;
-        }
-      }
-      context.customCommandAliases[cc].insert(targetName);
+    if (target->GetType() == cmState::GLOBAL_TARGET) {
+      if (!outputGlobals)
+        continue;
     } else {
-      // No merged outputs, so this command must always be run.
-      // Make it's name unique to its host target
-      targetName += "-";
-      targetName += hostTargetName;
+      if (outputGlobals)
+        continue;
     }
 
-    // Take the dependencies listed and split into targets and files.
-    const std::vector<std::string>& depends = ccg.GetDepends();
-    for (std::vector<std::string>::const_iterator iter = depends.begin();
-         iter != depends.end(); ++iter) {
-      const std::string& dep = *iter;
-
-      bool isTarget = context.self->FindTarget(dep) != NULL;
-      if (isTarget) {
-        orderDependencies.push_back(dep + "-" + configName);
-      } else {
-        inputs.push_back(dep);
-      }
-    }
-
-#ifdef _WIN32
-    const std::string shellExt = ".bat";
-#else
-    const std::string shellExt = ".sh";
-#endif
-
-    std::string workingDirectory = ccg.GetWorkingDirectory();
-    if (workingDirectory.empty()) {
-      workingDirectory = makefile->GetCurrentOutputDirectory();
-      workingDirectory += "/";
-    }
-
-    std::string scriptFileName(workingDirectory + targetName + ".bat");
-    cmsys::ofstream scriptFile(scriptFileName.c_str());
-
-    for (unsigned i = 0; i != ccg.GetNumberOfCommands(); ++i) {
-      std::string args;
-      ccg.AppendArguments(i, args);
-      cmSystemTools::ReplaceString(args, "$$", "$");
-      cmSystemTools::ReplaceString(args, FASTBUILD_DOLLAR_TAG, "$");
-#ifdef _WIN32
-      // in windows batch, '%' is a special character that needs to be doubled
-      // to be escaped
-      cmSystemTools::ReplaceString(args, "%", "%%");
-#endif
-      Detection::ResolveFastbuildVariables(args, configName);
-
-      std::string command(ccg.GetCommand(i));
-      cmSystemTools::ReplaceString(command, FASTBUILD_DOLLAR_TAG, "$");
-      Detection::ResolveFastbuildVariables(command, configName);
-
-      scriptFile << Quote(command, "\"") << args << std::endl;
-    }
-
-    // Write out an exec command
-    /*
-    Exec(alias); (optional)Alias
-    {
-            .ExecExecutable; Executable to run
-            .ExecInput; Input file to pass to executable
-            .ExecOutput; Output file generated by executable
-            .ExecArguments; (optional)Arguments to pass to executable
-            .ExecWorkingDir; (optional)Working dir to set for executable
-
-            ; Additional options
-            .PreBuildDependencies; (optional)Force targets to be built before
-    this Exec(Rarely needed,
-            ; but useful when Exec relies on externally generated files).
-    }
-    */
-
-    std::for_each(inputs.begin(), inputs.end(),
-                  &Detection::UnescapeFastbuildVariables);
-    std::for_each(mergedOutputs.begin(), mergedOutputs.end(),
-                  &Detection::UnescapeFastbuildVariables);
-
-    context.fc.WriteCommand("Exec", Quote(targetName));
-    context.fc.WritePushScope();
-    {
-#ifdef _WIN32
-      context.fc.WriteVariable("ExecExecutable",
-                               Quote(cmSystemTools::FindProgram("cmd.exe")));
-      context.fc.WriteVariable("ExecArguments", Quote("/C " + scriptFileName));
-#else
-      context.fc.WriteVariable("ExecExecutable", Quote(scriptFileName));
-#endif
-      if (!workingDirectory.empty()) {
-        context.fc.WriteVariable("ExecWorkingDir", Quote(workingDirectory));
-      }
-
-      if (inputs.empty()) {
-        // inputs.push_back("dummy-in");
-      }
-      context.fc.WriteArray("ExecInput", Wrap(inputs));
-
-      if (mergedOutputs.empty()) {
-        context.fc.WriteVariable("ExecUseStdOutAsOutput", "true");
-
-        std::string outputDir =
-          target.GetMakefile()->GetStartOutputDirectory();
-        mergedOutputs.push_back(outputDir + "/dummy-out-" + targetName +
-                                ".txt");
-      }
-      // Currently fastbuild doesn't support more than 1
-      // output for a custom command (soon to change hopefully).
-      // so only use the first one
-      context.fc.WriteVariable("ExecOutput", Quote(mergedOutputs[0]));
-    }
-    context.fc.WritePopScope();
-  }
-
-  static void WriteCustomBuildSteps(
-    GenerationContext& context, cmLocalFastbuildGenerator* lg,
-    cmTarget& target, const std::vector<cmCustomCommand>& commands,
-    const std::string& buildStep, const std::vector<std::string>& orderDeps)
-  {
-    if (commands.empty()) {
-      return;
-    }
-
-    const std::string& targetName = target.GetName();
-
-    // Now output the commands
-    std::vector<std::string>::const_iterator
-      iter = context.self->GetConfigurations().begin(),
-      end = context.self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
+    // Define compile flags
+    std::vector<std::string> configs;
+    context.root->GetMakefile()->GetConfigurations(configs, false);
+    for (std::vector<std::string>::const_iterator iter = configs.begin();
+         iter != configs.end(); ++iter) {
       const std::string& configName = *iter;
-
-      context.fc.WriteVariable("buildStep_" + buildStep + "_" + configName,
-                               "");
-      context.fc.WritePushScopeStruct();
-
-      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
-
-      context.fc.WriteArray("PreBuildDependencies",
-                            Wrap(orderDeps, "'", "-" + configName + "'"), "+");
-
-      std::string baseName = targetName + "-" + buildStep + "-" + configName;
-      int commandCount = 1;
-      std::vector<std::string> customCommandTargets;
-      for (std::vector<cmCustomCommand>::const_iterator ccIter =
-             commands.begin();
-           ccIter != commands.end(); ++ccIter) {
-        const cmCustomCommand& cc = *ccIter;
-
-        std::stringstream customCommandTargetName;
-        customCommandTargetName << baseName << (commandCount++);
-
-        std::string customCommandTargetNameStr = customCommandTargetName.str();
-        WriteCustomCommand(context, &cc, lg, target, configName,
-                           customCommandTargetNameStr, targetName);
-        customCommandTargets.push_back(customCommandTargetNameStr);
-      }
-
-      // Write an alias for this object group to group them all together
-      context.fc.WriteCommand("Alias", Quote(baseName));
-      context.fc.WritePushScope();
-      context.fc.WriteArray("Targets", Wrap(customCommandTargets, "'", "'"));
-      context.fc.WritePopScope();
-
-      context.fc.WritePopScope();
-    }
-  }
-
-  static bool WriteCustomBuildRules(GenerationContext& context,
-                                    cmLocalFastbuildGenerator* lg,
-                                    cmGeneratorTarget* gt, cmTarget& target)
-  {
-    bool hasCustomCommands = false;
-    const std::string& targetName = target.GetName();
-
-    // Iterating over all configurations
-    std::vector<std::string>::const_iterator
-      iter = context.self->GetConfigurations().begin(),
-      end = context.self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
-      std::string configName = *iter;
-
-      context.fc.WriteVariable("CustomCommands_" + configName, "");
-      context.fc.WritePushScopeStruct();
-
-      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
-
-      // Figure out the list of custom build rules in use by this target
-      // get a list of source files
-      std::vector<cmSourceFile const*> customCommands;
-      gt->GetCustomCommands(customCommands, configName);
-
-      if (!customCommands.empty()) {
-        // Presort the commands to adjust for dependencies
-        // In a number of cases, the commands inputs will be the outputs
-        // from another command. Need to sort the commands to output them in
-        // order.
-        Detection::DependencySorter::CustomCommandHelper ccHelper = {
-          context.self, lg, configName
-        };
-        Detection::DependencySorter::Sort(ccHelper, customCommands);
-
-        std::vector<std::string> customCommandTargets;
-
-        // Write the custom command build rules for each configuration
-        int commandCount = 1;
-        std::string customCommandNameBase =
-          "CustomCommand-" + configName + "-";
-        for (std::vector<cmSourceFile const*>::iterator ccIter =
-               customCommands.begin();
-             ccIter != customCommands.end(); ++ccIter) {
-          const cmSourceFile* sourceFile = *ccIter;
-
-          std::stringstream customCommandTargetName;
-          customCommandTargetName << customCommandNameBase << (commandCount++);
-          customCommandTargetName
-            << "-"
-            << cmSystemTools::GetFilenameName(sourceFile->GetFullPath());
-          ;
-
-          std::string customCommandTargetNameStr =
-            customCommandTargetName.str();
-          WriteCustomCommand(context, sourceFile->GetCustomCommand(), lg,
-                             target, configName, customCommandTargetNameStr,
-                             targetName);
-
-          customCommandTargets.push_back(customCommandTargetNameStr);
-        }
-
-        std::string customCommandGroupName =
-          targetName + "-CustomCommands-" + configName;
-
-        // Write an alias for this object group to group them all together
-        context.fc.WriteCommand("Alias", Quote(customCommandGroupName));
-        context.fc.WritePushScope();
-        context.fc.WriteArray("Targets", Wrap(customCommandTargets, "'", "'"));
-        context.fc.WritePopScope();
-
-        // Now make everything use this as prebuilt dependencies
-        std::vector<std::string> tmp;
-        tmp.push_back(customCommandGroupName);
-        context.fc.WriteArray("PreBuildDependencies", Wrap(tmp), "+");
-
-        hasCustomCommands = true;
-      }
-
-      context.fc.WritePopScope();
-    }
-
-    return hasCustomCommands;
-  }
-
-  struct CompileCommand
-  {
-    std::string defines;
-    std::string flags;
-    std::map<std::string, std::vector<std::string> > sourceFiles;
-  };
-
-  static void WriteTargetDefinition(GenerationContext& context,
-                                    cmLocalFastbuildGenerator* lg,
-                                    cmTarget& target)
-  {
-    // Detection of the link command as follows:
-    std::string linkCommand = "Library";
-    switch (target.GetType()) {
-      case cmTarget::INTERFACE_LIBRARY:
-        // We don't write out interface libraries.
-        return;
-      case cmTarget::EXECUTABLE: {
-        linkCommand = "Executable";
-        break;
-      }
-      case cmTarget::SHARED_LIBRARY: {
-        linkCommand = "DLL";
-        break;
-      }
-      case cmTarget::STATIC_LIBRARY:
-      case cmTarget::MODULE_LIBRARY:
-      case cmTarget::OBJECT_LIBRARY: {
-        // No changes required
-        break;
-      }
-      case cmTarget::UTILITY:
-      case cmTarget::GLOBAL_TARGET: {
-        // No link command used
-        linkCommand = "NoLinkCommand";
-        break;
-      }
-      case cmTarget::UNKNOWN_LIBRARY: {
-        // Ignoring this target generation...
-        return;
-      }
-    }
-
-    const std::string& targetName = target.GetName();
-    cmGeneratorTarget* gt = context.self->GetGeneratorTarget(&target);
-
-    context.fc.WriteComment("Target definition: " + targetName);
-    context.fc.WritePushScope();
-
-    std::vector<std::string> dependencies;
-    Detection::DetectTargetCompileDependencies(context.self, target,
-                                               dependencies);
-
-    // Iterate over each configuration
-    // This time to define linker settings for each config
-    std::vector<std::string>::const_iterator
-      configIter = context.self->GetConfigurations().begin(),
-      configEnd = context.self->GetConfigurations().end();
-    for (; configIter != configEnd; ++configIter) {
-      const std::string& configName = *configIter;
-
-      context.fc.WriteVariable("BaseConfig_" + configName, "");
-      context.fc.WritePushScopeStruct();
-
-      context.fc.WriteCommand("Using", ".ConfigBase");
-
-      context.fc.WriteVariable("ConfigName", Quote(configName));
-
-      context.fc.WriteBlankLine();
-      context.fc.WriteComment("General output details:");
-      // Write out the output paths for the outcome of this target
-      {
-        Detection::FastbuildTargetNames targetNames;
-        Detection::DetectOutput(targetNames, target, configName);
-
-        context.fc.WriteVariable("TargetNameOut",
-                                 Quote(targetNames.targetNameOut));
-        context.fc.WriteVariable("TargetNameImport",
-                                 Quote(targetNames.targetNameImport));
-        context.fc.WriteVariable("TargetNamePDB",
-                                 Quote(targetNames.targetNamePDB));
-        context.fc.WriteVariable("TargetNameSO",
-                                 Quote(targetNames.targetNameSO));
-        context.fc.WriteVariable("TargetNameReal",
-                                 Quote(targetNames.targetNameReal));
-
-        // TODO: Remove this if these variables aren't used...
-        // They've been added for testing
-        context.fc.WriteVariable("TargetOutput",
-                                 Quote(targetNames.targetOutput));
-        context.fc.WriteVariable("TargetOutputImplib",
-                                 Quote(targetNames.targetOutputImplib));
-        context.fc.WriteVariable("TargetOutputReal",
-                                 Quote(targetNames.targetOutputReal));
-        context.fc.WriteVariable("TargetOutDir",
-                                 Quote(targetNames.targetOutputDir));
-        context.fc.WriteVariable("TargetOutCompilePDBDir",
-                                 Quote(targetNames.targetOutputCompilePDBDir));
-        context.fc.WriteVariable("TargetOutPDBDir",
-                                 Quote(targetNames.targetOutputPDBDir));
-
-        // Compile directory always needs to exist
-        EnsureDirectoryExists(targetNames.targetOutputCompilePDBDir, context);
-
-        if (target.GetType() != cmTarget::OBJECT_LIBRARY) {
-          // on Windows the output dir is already needed at compile time
-          // ensure the directory exists (OutDir test)
-          EnsureDirectoryExists(targetNames.targetOutputDir, context);
-          EnsureDirectoryExists(targetNames.targetOutputPDBDir, context);
-        }
-      }
-
-      // Write the dependency list in here too
-      // So all dependant libraries are built before this one is
-      // This is incase this library depends on code generated from previous
-      // ones
-      {
-        context.fc.WriteArray("PreBuildDependencies",
-                              Wrap(dependencies, "'", "-" + configName + "'"));
-      }
-
-      context.fc.WritePopScope();
-    }
-
-    // Output the prebuild/Prelink commands
-    WriteCustomBuildSteps(context, lg, target, target.GetPreBuildCommands(),
-                          "PreBuild", dependencies);
-    WriteCustomBuildSteps(context, lg, target, target.GetPreLinkCommands(),
-                          "PreLink", dependencies);
-
-    // Iterate over each configuration
-    // This time to define prebuild and post build targets for each config
-    configIter = context.self->GetConfigurations().begin();
-    configEnd = context.self->GetConfigurations().end();
-    for (; configIter != configEnd; ++configIter) {
-      const std::string& configName = *configIter;
-
-      context.fc.WriteVariable("BaseCompilationConfig_" + configName, "");
-      context.fc.WritePushScopeStruct();
-
-      context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
-
-      // Add to the list of prebuild deps
-      // The prelink and prebuild commands
-      {
-        std::vector<std::string> preBuildSteps;
-        if (!target.GetPreBuildCommands().empty()) {
-          preBuildSteps.push_back("PreBuild");
-        }
-        if (!target.GetPreLinkCommands().empty()) {
-          preBuildSteps.push_back("PreLink");
-        }
-
-        if (!preBuildSteps.empty()) {
-          context.fc.WriteArray("PreBuildDependencies",
-                                Wrap(preBuildSteps, "'" + targetName + "-",
-                                     "-" + configName + "'"),
-                                "+");
-        }
-      }
-
-      context.fc.WritePopScope();
-    }
-
-    // Write the custom build rules
-    bool hasCustomBuildRules = WriteCustomBuildRules(context, lg, gt, target);
-
-    // Figure out the list of languages in use by this target
-    std::vector<std::string> linkableDeps;
-    std::vector<std::string> orderDeps;
-    std::set<std::string> languages;
-    Detection::DetectLanguages(languages, context.self, target);
-
-    // Write the object list definitions for each language
-    // stored in this target
-    for (std::set<std::string>::iterator langIter = languages.begin();
-         langIter != languages.end(); ++langIter) {
-      const std::string& objectGroupLanguage = *langIter;
-      std::string ruleObjectGroupName = "ObjectGroup_" + objectGroupLanguage;
-      linkableDeps.push_back(ruleObjectGroupName);
-
-      context.fc.WriteVariable(ruleObjectGroupName, "");
-      context.fc.WritePushScopeStruct();
-
-      // Iterating over all configurations
-      configIter = context.self->GetConfigurations().begin();
-      for (; configIter != configEnd; ++configIter) {
-        const std::string& configName = *configIter;
-        context.fc.WriteVariable("ObjectConfig_" + configName, "");
-        context.fc.WritePushScopeStruct();
-
-        context.fc.WriteCommand("Using",
-                                ".BaseCompilationConfig_" + configName);
-        context.fc.WriteCommand("Using", ".CustomCommands_" + configName);
-
-        context.fc.WriteBlankLine();
-        context.fc.WriteComment("Compiler options:");
-
-        // Compiler options
-        std::string baseCompileFlags;
-        {
-          // Remove the command from the front and leave the flags behind
-          std::string compileCmd;
-          Detection::DetectBaseCompileCommand(compileCmd, lg, target,
-                                              objectGroupLanguage);
-
-          // No need to double unescape the variables
-          // Detection::UnescapeFastbuildVariables(compileCmd);
-
-          std::string executable;
-          Detection::SplitExecutableAndFlags(compileCmd, executable,
-                                             baseCompileFlags);
-
-          context.fc.WriteVariable("CompilerCmdBaseFlags",
-                                   Quote(baseCompileFlags));
-
-          std::string compilerName = ".Compiler_" + objectGroupLanguage;
-          context.fc.WriteVariable("Compiler", compilerName);
-        }
-
-        std::map<std::string, CompileCommand> commandPermutations;
-
-        // Source files
-        context.fc.WriteBlankLine();
-        context.fc.WriteComment("Source files:");
-        {
-          // get a list of source files
-          std::vector<cmSourceFile const*> objectSources;
-          gt->GetObjectSources(objectSources, configName);
-
-          std::vector<cmSourceFile const*> filteredObjectSources;
-          Detection::FilterSourceFiles(filteredObjectSources, objectSources,
-                                       objectGroupLanguage);
-
-          // Figure out the compilation commands for all
-          // the translation units in the compilation.
-          // Detect if one of them is a PreCompiledHeader
-          // and extract it to be used in a precompiled header
-          // generation step.
-          for (std::vector<cmSourceFile const*>::iterator sourceIter =
-                 filteredObjectSources.begin();
-               sourceIter != filteredObjectSources.end(); ++sourceIter) {
-            cmSourceFile const* srcFile = *sourceIter;
-            std::string sourceFile = srcFile->GetFullPath();
-
-            // Detect flags and defines
-            std::string compilerFlags;
-            Detection::DetectCompilerFlags(compilerFlags, lg, gt, target,
-                                           srcFile, objectGroupLanguage,
-                                           configName);
-            std::string compileDefines = Detection::ComputeDefines(
-              lg, target, srcFile, configName, objectGroupLanguage);
-
-            Detection::UnescapeFastbuildVariables(compilerFlags);
-            Detection::UnescapeFastbuildVariables(compileDefines);
-
-            std::string configKey = compilerFlags + "{|}" + compileDefines;
-            CompileCommand& command = commandPermutations[configKey];
-            command.sourceFiles[srcFile->GetLocation().GetDirectory()]
-              .push_back(sourceFile);
-            command.flags = compilerFlags;
-            command.defines = compileDefines;
-          }
-        }
-
-        // Iterate over all subObjectGroups
-        std::string objectGroupRuleName =
-          targetName + "-" + ruleObjectGroupName + "-" + configName;
-        std::vector<std::string> configObjectGroups;
-        int groupNameCount = 1;
-        for (std::map<std::string, CompileCommand>::iterator groupIter =
-               commandPermutations.begin();
-             groupIter != commandPermutations.end(); ++groupIter) {
-          context.fc.WritePushScope();
-
-          const CompileCommand& command = groupIter->second;
-
-          context.fc.WriteVariable("CompileDefineFlags",
-                                   Quote(command.defines));
-          context.fc.WriteVariable("CompileFlags", Quote(command.flags));
-          context.fc.WriteVariable(
-            "CompilerOptions",
-            Quote(
-              "$CompileFlags$ $CompileDefineFlags$ $CompilerCmdBaseFlags$"));
-
-          if (objectGroupLanguage == "RC") {
-            context.fc.WriteVariable("CompilerOutputExtension", Quote(".res"));
-          } else {
-            context.fc.WriteVariable(
-              "CompilerOutputExtension",
-              Quote("." + objectGroupLanguage + ".obj"));
-          }
-
-          std::map<std::string, std::vector<std::string> >::const_iterator
-            objectListIt;
-          for (objectListIt = command.sourceFiles.begin();
-               objectListIt != command.sourceFiles.end(); ++objectListIt) {
-            const std::string folderName(
-              Detection::GetLastFolderName(objectListIt->first));
-            std::stringstream ruleName;
-            ruleName << objectGroupRuleName << "-" << folderName << "-"
-                     << (groupNameCount++);
-
-            context.fc.WriteCommand("ObjectList", Quote(ruleName.str()));
-            context.fc.WritePushScope();
-
-            context.fc.WriteArray("CompilerInputFiles",
-                                  Wrap(objectListIt->second, "'", "'"));
-
-            configObjectGroups.push_back(ruleName.str());
-
-            std::string targetCompileOutDirectory =
-              Detection::DetectTargetCompileOutputDir(lg, target, configName);
-            context.fc.WriteVariable(
-              "CompilerOutputPath",
-              Quote(targetCompileOutDirectory + "/" + folderName));
-
-            // Unity source files:
-            context.fc.WriteVariable("UnityInputFiles", ".CompilerInputFiles");
-
-            /*
-            if (Detection::DetectPrecompiledHeader(command.flags + " " +
-                    baseCompileFlags + " " + command.defines,
-                    preCompiledHeaderInput,
-                    preCompiledHeaderOutput,
-                    preCompiledHeaderOptions)
-            */
-            context.fc.WritePopScope();
-          }
-
-          context.fc.WritePopScope();
-        }
-
-        if (!configObjectGroups.empty()) {
-          // Write an alias for this object group to group them all together
-          context.fc.WriteCommand("Alias", Quote(objectGroupRuleName));
-          context.fc.WritePushScope();
-          context.fc.WriteArray("Targets", Wrap(configObjectGroups, "'", "'"));
-          context.fc.WritePopScope();
-        }
-
-        context.fc.WritePopScope();
-      }
-      context.fc.WritePopScope();
-    }
-
-    // Object libraries do not have linker stages
-    // nor utilities
-    bool hasLinkerStage = target.GetType() != cmTarget::OBJECT_LIBRARY &&
-      target.GetType() != cmTarget::UTILITY &&
-      target.GetType() != cmTarget::GLOBAL_TARGET;
-
-    // Iterate over each configuration
-    // This time to define linker settings for each config
-    std::vector<std::string>::const_iterator
-      iter = context.self->GetConfigurations().begin(),
-      end = context.self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
-      const std::string& configName = *iter;
-
-      std::string linkRuleName = targetName + "-link-" + configName;
-
-      if (hasLinkerStage) {
-
-        context.fc.WriteVariable("LinkerConfig_" + configName, "");
-        context.fc.WritePushScopeStruct();
-
-        context.fc.WriteCommand("Using", ".BaseConfig_" + configName);
-
-        context.fc.WriteBlankLine();
-        context.fc.WriteComment("Linker options:");
-        // Linker options
-        {
-          std::string linkLibs;
-          std::string targetFlags;
-          std::string linkFlags;
-          std::string frameworkPath;
-          std::string dummyLinkPath;
-
-          lg->GetTargetFlags(linkLibs, targetFlags, linkFlags, frameworkPath,
-                             dummyLinkPath, gt, false);
-
-          std::string linkPath;
-          Detection::DetectLinkerLibPaths(linkPath, lg, target, configName);
-
-          Detection::UnescapeFastbuildVariables(linkLibs);
-          Detection::UnescapeFastbuildVariables(targetFlags);
-          Detection::UnescapeFastbuildVariables(linkFlags);
-          Detection::UnescapeFastbuildVariables(frameworkPath);
-          Detection::UnescapeFastbuildVariables(linkPath);
-
-          linkPath = frameworkPath + linkPath;
-
-          if (target.IsExecutableWithExports()) {
-            const char* defFileFlag =
-              lg->GetMakefile()->GetDefinition("CMAKE_LINK_DEF_FILE_FLAG");
-            const std::string defFile =
-              gt->GetModuleDefinitionFile(configName);
-            if (!defFile.empty()) {
-              linkFlags += defFileFlag + defFile;
-            }
-          }
-
-          context.fc.WriteVariable("LinkPath", "'" + linkPath + "'");
-          context.fc.WriteVariable("LinkLibs", "'" + linkLibs + "'");
-          context.fc.WriteVariable("LinkFlags", "'" + linkFlags + "'");
-          context.fc.WriteVariable("TargetFlags", "'" + targetFlags + "'");
-
-          // Remove the command from the front and leave the flags behind
-          std::string linkCmd;
-          if (!Detection::DetectBaseLinkerCommand(linkCmd, lg, target, gt,
-                                                  configName)) {
-            return;
-          }
-          // No need to do this, because the function above has already escaped
-          // things appropriately
-          // Detection::UnescapeFastbuildVariables(linkCmd);
-
-          std::string executable;
-          std::string flags;
-          Detection::SplitExecutableAndFlags(linkCmd, executable, flags);
-
-          std::string language = target.GetLinkerLanguage(configName);
-          std::string linkerType = lg->GetMakefile()->GetSafeDefinition(
-            "CMAKE_" + language + "_COMPILER_ID");
-
-          context.fc.WriteVariable("Linker", Quote(executable));
-          context.fc.WriteVariable("LinkerType", Quote(linkerType));
-          context.fc.WriteVariable("BaseLinkerOptions", Quote(flags));
-
-          context.fc.WriteVariable("LinkerOutput", "'$TargetOutput$'");
-          context.fc.WriteVariable("LinkerOptions",
-                                   "'$BaseLinkerOptions$ $LinkLibs$'");
-
-          context.fc.WriteArray("Libraries",
-                                Wrap(linkableDeps, "'" + targetName + "-",
-                                     "-" + configName + "'"));
-
-          // Now detect the extra dependencies for linking
-          {
-            std::vector<std::string> extraDependencies;
-            Detection::DetectTargetObjectDependencies(
-              context.self, target, configName, extraDependencies);
-            Detection::DetectTargetLinkDependencies(target, configName,
-                                                    extraDependencies);
-
-            std::for_each(extraDependencies.begin(), extraDependencies.end(),
-                          Detection::UnescapeFastbuildVariables);
-
-            context.fc.WriteArray("Libraries",
-                                  Wrap(extraDependencies, "'", "'"), "+");
-          }
-
-          context.fc.WriteCommand(linkCommand, Quote(linkRuleName));
-          context.fc.WritePushScope();
-          if (linkCommand == "Library") {
-            context.fc.WriteComment(
-              "Convert the linker options to work with libraries");
-
-            // Push dummy definitions for compilation variables
-            // These variables are required by the Library command
-            context.fc.WriteVariable("Compiler", ".Compiler_dummy");
-            context.fc.WriteVariable(
-              "CompilerOptions",
-              "'-c $FB_INPUT_1_PLACEHOLDER$ $FB_INPUT_2_PLACEHOLDER$'");
-            context.fc.WriteVariable("CompilerOutputPath", "'/dummy/'");
-
-            // These variables are required by the Library command as well
-            // we just need to transfer the values in the linker variables
-            // to these locations
-            context.fc.WriteVariable("Librarian", "'$Linker$'");
-            context.fc.WriteVariable("LibrarianOptions", "'$LinkerOptions$'");
-            context.fc.WriteVariable("LibrarianOutput", "'$LinkerOutput$'");
-
-            context.fc.WriteVariable("LibrarianAdditionalInputs",
-                                     ".Libraries");
-          }
-          context.fc.WritePopScope();
-        }
-        context.fc.WritePopScope();
-      }
-    }
-
-    if (!target.GetPreBuildCommands().empty()) {
-      orderDeps.push_back("PreBuild");
-    }
-    if (!target.GetPreLinkCommands().empty()) {
-      orderDeps.push_back("PreLink");
-    }
-    if (hasCustomBuildRules) {
-      orderDeps.push_back("CustomCommands");
-    }
-    if (hasLinkerStage) {
-      linkableDeps.push_back("link");
-      orderDeps.push_back("link");
-    }
-
-    // Output the postbuild commands
-    WriteCustomBuildSteps(context, lg, target, target.GetPostBuildCommands(),
-                          "PostBuild", Wrap(orderDeps, targetName + "-", ""));
-
-    // Always add the pre/post build steps as
-    // part of the alias.
-    // This way, if there are ONLY build steps, then
-    // things should still work too.
-    if (!target.GetPostBuildCommands().empty()) {
-      orderDeps.push_back("PostBuild");
-    }
-
-    // Output a list of aliases
-    WriteTargetAliases(context, target, linkableDeps, orderDeps);
-
-    context.fc.WritePopScope();
-  }
-
-  static void WriteTargetAliases(GenerationContext& context, cmTarget& target,
-                                 const std::vector<std::string>& linkableDeps,
-                                 const std::vector<std::string>& orderDeps)
-  {
-    const std::string& targetName = target.GetName();
-
-    std::vector<std::string>::const_iterator
-      iter = context.self->GetConfigurations().begin(),
-      end = context.self->GetConfigurations().end();
-    for (; iter != end; ++iter) {
-      const std::string& configName = *iter;
-
-      if (!linkableDeps.empty()) {
-        context.fc.WriteCommand(
-          "Alias", Quote(targetName + "-" + configName + "-products"));
-        context.fc.WritePushScope();
-        context.fc.WriteArray(
-          "Targets",
-          Wrap(linkableDeps, "'" + targetName + "-", "-" + configName + "'"));
-        context.fc.WritePopScope();
-      }
-
-      if (!orderDeps.empty() || !linkableDeps.empty()) {
-        context.fc.WriteCommand("Alias", Quote(targetName + "-" + configName));
-        context.fc.WritePushScope();
-        context.fc.WriteArray(
-          "Targets",
-          Wrap(linkableDeps, "'" + targetName + "-", "-" + configName + "'"));
-        context.fc.WriteArray(
-          "Targets",
-          Wrap(orderDeps, "'" + targetName + "-", "-" + configName + "'"),
-          "+");
-        context.fc.WritePopScope();
+      std::string aliasName = targetName + "-" + configName;
+
+      perTarget[targetName].push_back(aliasName);
+      if (!gg->IsExcluded(context.root, target)) {
+        perConfig[configName].push_back(aliasName);
       }
     }
   }
 
-  static void WriteTargetUtilityDefinition(GenerationContext& context,
-                                           cmLocalFastbuildGenerator* lg,
-                                           cmTarget& target)
-  {
-    WriteTargetDefinition(context, lg, target);
-  }
-
-  static void WriteTargetDefinitions(GenerationContext& context,
-                                     bool outputGlobals)
-  {
-    context.fc.WriteSectionHeader((outputGlobals) ? "Global Target Definitions"
-                                                  : "Target Definitions");
-
-    // Now iterate each target in order
-    for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
-         targetIter != context.orderedTargets.end(); ++targetIter) {
-      const cmTarget* constTarget = (*targetIter);
-      if (constTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
-        continue;
-      }
-
-      TargetContextMap::iterator findResult =
-        context.targetContexts.find(constTarget);
-      if (findResult == context.targetContexts.end()) {
-        continue;
-      }
-
-      cmTarget* target = findResult->second.target;
-      cmLocalFastbuildGenerator* lg = findResult->second.lg;
-
-      if (target->GetType() == cmTarget::GLOBAL_TARGET) {
-        if (!outputGlobals)
-          continue;
-      } else {
-        if (outputGlobals)
-          continue;
-      }
-
-      switch (target->GetType()) {
-        case cmTarget::EXECUTABLE:
-        case cmTarget::SHARED_LIBRARY:
-        case cmTarget::STATIC_LIBRARY:
-        case cmTarget::MODULE_LIBRARY:
-        case cmTarget::OBJECT_LIBRARY:
-          WriteTargetDefinition(context, lg, *target);
-          break;
-        case cmTarget::UTILITY:
-        case cmTarget::GLOBAL_TARGET:
-          WriteTargetUtilityDefinition(context, lg, *target);
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  static void WriteAliases(GenerationContext& context, bool outputGlobals)
-  {
-    context.fc.WriteSectionHeader("Aliases");
-
-    // Write the following aliases:
-    // Per Target
-    // Per Config
-    // All
-
-    typedef std::map<std::string, std::vector<std::string> > TargetListMap;
-    TargetListMap perConfig;
-    TargetListMap perTarget;
-
-    for (OrderedTargets::iterator targetIter = context.orderedTargets.begin();
-         targetIter != context.orderedTargets.end(); ++targetIter) {
-      const cmTarget* constTarget = (*targetIter);
-      if (constTarget->GetType() == cmTarget::INTERFACE_LIBRARY) {
-        continue;
-      }
-
-      TargetContextMap::iterator findResult =
-        context.targetContexts.find(constTarget);
-      if (findResult == context.targetContexts.end()) {
-        continue;
-      }
-
-      cmTarget* target = findResult->second.target;
-      const std::string& targetName = target->GetName();
-
-      if (target->GetType() == cmTarget::GLOBAL_TARGET) {
-        if (!outputGlobals)
-          continue;
-      } else {
-        if (outputGlobals)
-          continue;
-      }
-
-      // Define compile flags
-      std::vector<std::string>::const_iterator
-        iter = context.self->GetConfigurations().begin(),
-        end = context.self->GetConfigurations().end();
-      for (; iter != end; ++iter) {
-        const std::string& configName = *iter;
-        std::string aliasName = targetName + "-" + configName;
-
-        perTarget[targetName].push_back(aliasName);
-
-        if (!Detection::IsExcludedFromAll(target)) {
-          perConfig[configName].push_back(aliasName);
-        }
-      }
-    }
-
-    if (!outputGlobals) {
-      context.fc.WriteComment("Per config");
-      std::vector<std::string> aliasTargets;
-      for (TargetListMap::iterator iter = perConfig.begin();
-           iter != perConfig.end(); ++iter) {
-        const std::string& configName = iter->first;
-        const std::vector<std::string>& targets = iter->second;
-
-        context.fc.WriteCommand("Alias", Quote(configName));
-        context.fc.WritePushScope();
-        context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
-        context.fc.WritePopScope();
-
-        aliasTargets.clear();
-        aliasTargets.push_back(configName);
-        context.fc.WriteCommand("Alias", Quote("ALL_BUILD-" + configName));
-        context.fc.WritePushScope();
-        context.fc.WriteArray("Targets", Wrap(aliasTargets, "'", "'"));
-        context.fc.WritePopScope();
-      }
-    }
-
-    context.fc.WriteComment("Per targets");
-    for (TargetListMap::iterator iter = perTarget.begin();
-         iter != perTarget.end(); ++iter) {
-      const std::string& targetName = iter->first;
+  if (!outputGlobals) {
+    context.fc.WriteComment("Per config");
+    std::vector<std::string> aliasTargets;
+    for (TargetListMap::iterator iter = perConfig.begin();
+         iter != perConfig.end(); ++iter) {
+      const std::string& configName = iter->first;
       const std::vector<std::string>& targets = iter->second;
 
-      context.fc.WriteCommand("Alias", "'" + targetName + "'");
+      context.fc.WriteCommand("Alias", Quote(configName));
       context.fc.WritePushScope();
       context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
       context.fc.WritePopScope();
-    }
 
-    if (!outputGlobals) {
-      context.fc.WriteComment("All");
-      context.fc.WriteCommand("Alias", "'All'");
+      aliasTargets.clear();
+      aliasTargets.push_back(configName);
+      context.fc.WriteCommand("Alias", Quote("ALL_BUILD-" + configName));
       context.fc.WritePushScope();
-      context.fc.WriteArray("Targets",
-                            Wrap(context.self->GetConfigurations(), "'", "'"));
+      context.fc.WriteArray("Targets", Wrap(aliasTargets, "'", "'"));
       context.fc.WritePopScope();
     }
   }
-};
+
+  context.fc.WriteComment("Per targets");
+  for (TargetListMap::iterator iter = perTarget.begin();
+       iter != perTarget.end(); ++iter) {
+    const std::string& targetName = iter->first;
+    const std::vector<std::string>& targets = iter->second;
+
+    context.fc.WriteCommand("Alias", "'" + targetName + "'");
+    context.fc.WritePushScope();
+    context.fc.WriteArray("Targets", Wrap(targets, "'", "'"));
+    context.fc.WritePopScope();
+  }
+
+  if (!outputGlobals) {
+    std::vector<std::string> configs;
+    context.root->GetMakefile()->GetConfigurations(configs, false);
+
+    context.fc.WriteComment("All");
+    context.fc.WriteCommand("Alias", "'All'");
+    context.fc.WritePushScope();
+    context.fc.WriteArray("Targets", Wrap(configs, "'", "'"));
+    context.fc.WritePopScope();
+  }
+}
 
 //----------------------------------------------------------------------------
 cmGlobalGeneratorFactory* cmGlobalFastbuildGenerator::NewFactory()
 {
-  return new Factory();
+  return new cmGlobalGeneratorSimpleFactory<cmGlobalFastbuildGenerator>();
 }
 
 //----------------------------------------------------------------------------
-cmGlobalFastbuildGenerator::cmGlobalFastbuildGenerator()
+cmGlobalFastbuildGenerator::cmGlobalFastbuildGenerator(cmake* cm)
+  : cmGlobalCommonGenerator(cm)
 {
+#ifdef _WIN32
+  cm->GetState()->SetWindowsShell(true);
+#endif
   this->FindMakeProgramFile = "CMakeFastbuildFindMake.cmake";
 }
 
@@ -2700,17 +948,10 @@ cmGlobalFastbuildGenerator::~cmGlobalFastbuildGenerator()
 }
 
 //----------------------------------------------------------------------------
-std::string cmGlobalFastbuildGenerator::GetName() const
+cmLocalGenerator* cmGlobalFastbuildGenerator::CreateLocalGenerator(
+  cmMakefile* makefile)
 {
-  return fastbuildGeneratorName;
-}
-
-//----------------------------------------------------------------------------
-cmLocalGenerator* cmGlobalFastbuildGenerator::CreateLocalGenerator()
-{
-  cmLocalGenerator* lg = new cmLocalFastbuildGenerator();
-  lg->SetGlobalGenerator(this);
-  return lg;
+  return new cmLocalFastbuildGenerator(this, makefile);
 }
 
 //----------------------------------------------------------------------------
@@ -2719,7 +960,15 @@ void cmGlobalFastbuildGenerator::EnableLanguage(
 {
   // Create list of configurations requested by user's cache, if any.
   this->cmGlobalGenerator::EnableLanguage(lang, mf, optional);
-  Detail::Detection::DetectConfigurations(this, mf, this->Configurations);
+
+  if (!mf->GetDefinition("CMAKE_CONFIGURATION_TYPES")) {
+    mf->AddCacheDefinition(
+      "CMAKE_CONFIGURATION_TYPES", "Debug;Release;MinSizeRel;RelWithDebInfo",
+      "Semicolon separated list of supported configuration types, "
+      "only supports Debug, Release, MinSizeRel, and RelWithDebInfo, "
+      "anything else will be ignored.",
+      cmState::STRING);
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -2821,9 +1070,9 @@ void cmGlobalFastbuildGenerator::ComputeTargetObjectDirectory(
 
   // Compute full path to object file directory for this target.
   std::string dir;
-  dir += gt->Makefile->GetCurrentOutputDirectory();
+  dir += gt->Makefile->GetCurrentBinaryDirectory();
   dir += "/";
-  dir += gt->LocalGenerator->GetTargetDirectory(*target);
+  dir += gt->LocalGenerator->GetTargetDirectory(gt);
   dir += "/";
   gt->ObjectDirectory = dir;
 }
@@ -2835,17 +1084,10 @@ const char* cmGlobalFastbuildGenerator::GetCMakeCFGIntDir() const
 }
 
 //----------------------------------------------------------------------------
-void cmGlobalFastbuildGenerator::GetTargetSets(
-  TargetDependSet& projectTargets, TargetDependSet& originalTargets,
-  cmLocalGenerator* root, GeneratorVector const& gv)
+void cmGlobalFastbuildGenerator::GetDocumentation(cmDocumentationEntry& entry)
 {
-  cmGlobalGenerator::GetTargetSets(projectTargets, originalTargets, root, gv);
-}
-//----------------------------------------------------------------------------
-const std::vector<std::string>& cmGlobalFastbuildGenerator::GetConfigurations()
-  const
-{
-  return Configurations;
+  entry.Name = cmGlobalFastbuildGenerator::GetActualName();
+  entry.Brief = "Generates build.bff files.";
 }
 
 //----------------------------------------------------------------------------

--- a/Source/cmGlobalFastbuildGenerator.cxx
+++ b/Source/cmGlobalFastbuildGenerator.cxx
@@ -359,7 +359,6 @@ void cmGlobalFastbuildGenerator::Detail::Detection::DependencySorter::
                                   std::vector<std::string>& outputs)
 {
   const cmCustomCommand* cc = entry->GetCustomCommand();
-  cmMakefile* makefile = lg->GetMakefile();
 
   // We need to generate the command for execution.
   cmCustomCommandGenerator ccg(*cc, configName, lg);
@@ -469,7 +468,7 @@ void cmGlobalFastbuildGenerator::Detail::Detection::DetectCompilerExtraFiles(
   return;
 
   if (compilerID == "MSVC") {
-    if (version.compare(0, 3, "18.") != std::string::npos) {
+    if (static_cast<size_t>(version.compare(0, 3, "18.")) != std::string::npos) {
       // Using vs2013
       const char* vs2013_extraFiles[13] = {
         "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
@@ -486,7 +485,7 @@ void cmGlobalFastbuildGenerator::Detail::Detection::DetectCompilerExtraFiles(
       };
       extraFiles.insert(extraFiles.end(), &vs2013_extraFiles[0],
                         &vs2013_extraFiles[13]);
-    } else if (version.compare(0, 3, "17.") != std::string::npos) {
+    } else if (static_cast<size_t>(version.compare(0, 3, "17.")) != std::string::npos) {
       // Using vs2012
       const char* vs2012_extraFiles[12] = {
         "$CompilerRoot$\\c1.dll", "$CompilerRoot$\\c1ast.dll",
@@ -983,7 +982,7 @@ void cmGlobalFastbuildGenerator::Generate()
 //----------------------------------------------------------------------------
 void cmGlobalFastbuildGenerator::GenerateBuildCommand(
   std::vector<std::string>& makeCommand, const std::string& makeProgram,
-  const std::string& projectName, const std::string& projectDir,
+  const std::string& /* projectName */, const std::string& projectDir,
   const std::string& targetName, const std::string& config, bool /*fast*/,
   bool /*verbose*/, std::vector<std::string> const& /*makeOptions*/)
 {
@@ -1066,8 +1065,6 @@ void cmGlobalFastbuildGenerator::AppendDirectoryForConfig(
 void cmGlobalFastbuildGenerator::ComputeTargetObjectDirectory(
   cmGeneratorTarget* gt) const
 {
-  cmTarget* target = gt->Target;
-
   // Compute full path to object file directory for this target.
   std::string dir;
   dir += gt->Makefile->GetCurrentBinaryDirectory();

--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -39,6 +39,12 @@ public:
   virtual void ComputeTargetObjectDirectory(cmGeneratorTarget*) const;
   virtual const char* GetCMakeCFGIntDir() const;
 
+  virtual void GetTargetSets(TargetDependSet& projectTargets,
+                             TargetDependSet& originalTargets,
+                             cmLocalGenerator* root, GeneratorVector const&);
+
+  const std::vector<std::string>& GetConfigurations() const;
+
 private:
   class Factory;
   class Detail;

--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -1,0 +1,49 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#ifndef cmGlobalFastbuildGenerator_h
+#define cmGlobalFastbuildGenerator_h
+
+#include "cmGlobalGenerator.h"
+
+class cmGlobalGeneratorFactory;
+
+/** \class cmGlobalFastbuildGenerator
+ * \brief Class for global fastbuild generator.
+ */
+class cmGlobalFastbuildGenerator : public cmGlobalGenerator
+{
+public:
+  cmGlobalFastbuildGenerator();
+  virtual ~cmGlobalFastbuildGenerator();
+
+  static cmGlobalGeneratorFactory* NewFactory();
+
+  void EnableLanguage(std::vector<std::string> const& lang, cmMakefile* mf,
+                      bool optional);
+  virtual void Generate();
+  virtual void GenerateBuildCommand(
+    std::vector<std::string>& makeCommand, const std::string& makeProgram,
+    const std::string& projectName, const std::string& projectDir,
+    const std::string& targetName, const std::string& config, bool fast,
+    bool verbose, std::vector<std::string> const& makeOptions);
+
+  ///! create the correct local generator
+  virtual cmLocalGenerator* CreateLocalGenerator();
+  virtual std::string GetName() const;
+
+  virtual void AppendDirectoryForConfig(const std::string& prefix,
+                                        const std::string& config,
+                                        const std::string& suffix,
+                                        std::string& dir);
+
+  virtual void ComputeTargetObjectDirectory(cmGeneratorTarget*) const;
+  virtual const char* GetCMakeCFGIntDir() const;
+
+private:
+  class Factory;
+  class Detail;
+
+  std::vector<std::string> Configurations;
+};
+
+#endif

--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -31,6 +31,8 @@ public:
   virtual cmLocalGenerator* CreateLocalGenerator();
   virtual std::string GetName() const;
 
+  virtual bool IsMultiConfig() { return true; }
+
   virtual void AppendDirectoryForConfig(const std::string& prefix,
                                         const std::string& config,
                                         const std::string& suffix,

--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -3,17 +3,22 @@
 #ifndef cmGlobalFastbuildGenerator_h
 #define cmGlobalFastbuildGenerator_h
 
+#include "cmGeneratedFileStream.h"
+#include "cmGlobalCommonGenerator.h"
 #include "cmGlobalGenerator.h"
+#include "cmLocalCommonGenerator.h"
+#include "cmLocalFastbuildGenerator.h"
 
 class cmGlobalGeneratorFactory;
+class cmCustomCommandGenerator;
 
 /** \class cmGlobalFastbuildGenerator
  * \brief Class for global fastbuild generator.
  */
-class cmGlobalFastbuildGenerator : public cmGlobalGenerator
+class cmGlobalFastbuildGenerator : public cmGlobalCommonGenerator
 {
 public:
-  cmGlobalFastbuildGenerator();
+  cmGlobalFastbuildGenerator(cmake* cm);
   virtual ~cmGlobalFastbuildGenerator();
 
   static cmGlobalGeneratorFactory* NewFactory();
@@ -28,10 +33,13 @@ public:
     bool verbose, std::vector<std::string> const& makeOptions);
 
   ///! create the correct local generator
-  virtual cmLocalGenerator* CreateLocalGenerator();
-  virtual std::string GetName() const;
+  virtual cmLocalGenerator* CreateLocalGenerator(cmMakefile* makefile);
+  virtual std::string GetName() const
+  {
+    return cmGlobalFastbuildGenerator::GetActualName();
+  }
 
-  virtual bool IsMultiConfig() { return true; }
+  virtual bool IsMultiConfig() const { return true; }
 
   virtual void AppendDirectoryForConfig(const std::string& prefix,
                                         const std::string& config,
@@ -41,11 +49,302 @@ public:
   virtual void ComputeTargetObjectDirectory(cmGeneratorTarget*) const;
   virtual const char* GetCMakeCFGIntDir() const;
 
-  virtual void GetTargetSets(TargetDependSet& projectTargets,
-                             TargetDependSet& originalTargets,
-                             cmLocalGenerator* root, GeneratorVector const&);
+  static std::string GetActualName() { return "Fastbuild"; }
 
-  const std::vector<std::string>& GetConfigurations() const;
+  /// Overloaded methods. @see cmGlobalGenerator::GetDocumentation()
+  static void GetDocumentation(cmDocumentationEntry& entry);
+
+  static bool SupportsToolset() { return false; }
+
+  /**
+   * Utilized by the generator factory to determine if this generator
+   * supports platforms.
+   */
+  static bool SupportsPlatform() { return false; }
+
+  static std::string Quote(const std::string& str,
+                           const std::string& quotation = "'");
+
+  static std::vector<std::string> Wrap(const std::vector<std::string>& in,
+                                       const std::string& prefix = "'",
+                                       const std::string& suffix = "'");
+
+  class Detail
+  {
+  public:
+    class FileContext
+    {
+    public:
+      FileContext();
+      void setFileName(const std::string fileName);
+      void close();
+      void WriteComment(const std::string& comment);
+      void WriteBlankLine();
+      void WriteHorizontalLine();
+      void WriteSectionHeader(const char* section);
+      void WritePushScope(char begin = '{', char end = '}');
+      void WritePushScopeStruct();
+      void WritePopScope();
+      void WriteVariable(const std::string& key, const std::string& value,
+                         const std::string& operation = "=");
+      void WriteCommand(const std::string& command,
+                        const std::string& value = std::string());
+      void WriteArray(const std::string& key,
+                      const std::vector<std::string>& values,
+                      const std::string& operation = "=");
+
+    private:
+      cmGeneratedFileStream fout;
+      std::string linePrefix;
+      std::string closingScope;
+    };
+    class Detection
+    {
+    public:
+      static void DetectLanguages(std::set<std::string>& languages,
+                                  const cmGeneratorTarget* generatorTarget);
+
+      static void FilterSourceFiles(
+        std::vector<cmSourceFile const*>& filteredSourceFiles,
+        std::vector<cmSourceFile const*>& sourceFiles,
+        const std::string& language);
+
+      static void DetectCompilerFlags(std::string& compileFlags,
+                                      cmLocalCommonGenerator* lg,
+                                      const cmGeneratorTarget* gt,
+                                      const cmSourceFile* source,
+                                      const std::string& language,
+                                      const std::string& configName);
+
+      struct DependencySorter
+      {
+        struct TargetHelper
+        {
+          cmGlobalFastbuildGenerator* gg;
+
+          void GetOutputs(const cmGeneratorTarget* entry,
+                          std::vector<std::string>& outputs);
+
+          void GetInputs(const cmGeneratorTarget* entry,
+                         std::vector<std::string>& inputs);
+        };
+
+        struct CustomCommandHelper
+        {
+          cmGlobalCommonGenerator* gg;
+          cmLocalCommonGenerator* lg;
+          const std::string& configName;
+
+          void GetOutputs(const cmSourceFile* entry,
+                          std::vector<std::string>& outputs);
+          void GetInputs(const cmSourceFile* entry,
+                         std::vector<std::string>& inputs);
+        };
+
+        template <class TType, class TTypeHelper>
+        static void Sort(TTypeHelper& helper, std::vector<TType*>& entries)
+        {
+          typedef std::vector<std::string> StringVector;
+          typedef std::vector<const TType*> OrderedEntrySet;
+          typedef std::map<std::string, const TType*> OutputMap;
+
+          // Build up a map of outputNames to entries
+          OutputMap outputMap;
+          for (typename OrderedEntrySet::iterator iter = entries.begin();
+               iter != entries.end(); ++iter) {
+            const TType* entry = *iter;
+            StringVector outputs;
+            helper.GetOutputs(entry, outputs);
+
+            for (StringVector::iterator outIter = outputs.begin();
+                 outIter != outputs.end(); ++outIter) {
+              outputMap[*outIter] = entry;
+            }
+          }
+
+          // Now build a forward and reverse map of dependencies
+          // Build the reverse graph,
+          // each target, and the set of things that depend upon it
+          typedef std::map<const TType*, std::vector<const TType*> > DepMap;
+          DepMap forwardDeps;
+          DepMap reverseDeps;
+          for (typename OrderedEntrySet::iterator iter = entries.begin();
+               iter != entries.end(); ++iter) {
+            const TType* entry = *iter;
+            std::vector<const TType*>& entryInputs = forwardDeps[entry];
+
+            StringVector inputs;
+            helper.GetInputs(entry, inputs);
+            for (StringVector::const_iterator inIter = inputs.begin();
+                 inIter != inputs.end(); ++inIter) {
+              const std::string& input = *inIter;
+              // Lookup the input in the output map and find the right entry
+              typename OutputMap::iterator findResult = outputMap.find(input);
+              if (findResult != outputMap.end()) {
+                const TType* dentry = findResult->second;
+                entryInputs.push_back(dentry);
+                reverseDeps[dentry].push_back(entry);
+              }
+            }
+          }
+
+          // We have all the information now.
+          // Clear the array passed in
+          entries.clear();
+
+          // Now iterate over each target with its list of dependencies.
+          // And dump out ones that have 0 dependencies.
+          bool written = true;
+          while (!forwardDeps.empty() && written) {
+            written = false;
+            for (typename DepMap::iterator iter = forwardDeps.begin();
+                 iter != forwardDeps.end(); ++iter) {
+              std::vector<const TType*>& fwdDeps = iter->second;
+              const TType* entry = iter->first;
+              if (!fwdDeps.empty()) {
+                // Looking for empty dependency lists.
+                // Those are the next to be written out
+                continue;
+              }
+
+              // dependency list is empty,
+              // add it to the output list
+              written = true;
+              entries.push_back(entry);
+
+              // Use reverse dependencies to determine
+              // what forward dep lists to adjust
+              std::vector<const TType*>& revDeps = reverseDeps[entry];
+              for (unsigned int i = 0; i < revDeps.size(); ++i) {
+                const TType* revDep = revDeps[i];
+
+                // Fetch the list of deps on that target
+                std::vector<const TType*>& revDepFwdDeps = forwardDeps[revDep];
+                // remove the one we just added from the list
+                revDepFwdDeps.erase(std::remove(revDepFwdDeps.begin(),
+                                                revDepFwdDeps.end(), entry),
+                                    revDepFwdDeps.end());
+              }
+
+              // Remove it from forward deps so not
+              // considered again
+              forwardDeps.erase(entry);
+
+              // Must break now as we've invalidated
+              // our forward deps iterator
+              break;
+            }
+          }
+
+          // Validation...
+          // Make sure we managed to find a place
+          // to insert every dependency.
+          // If this fires, then there is most likely
+          // a cycle in the graph...
+          assert(forwardDeps.empty());
+        }
+      };
+
+      typedef std::vector<const cmGeneratorTarget*> OrderedTargetSet;
+
+      // Iterate over all targets and remove the ones that are
+      // not needed for generation.
+      // i.e. the nested global targets
+      struct RemovalTest
+      {
+        bool operator()(const cmGeneratorTarget* target) const;
+      };
+
+      static void StripNestedGlobalTargets(OrderedTargetSet& orderedTargets);
+
+      static void DetectCompilerExtraFiles(
+        const std::string& compilerID, const std::string& version,
+        std::vector<std::string>& extraFiles);
+    };
+
+    class Generation
+    {
+    public:
+      typedef std::set<cmGeneratorTarget*> TargetContextList;
+      typedef std::map<const cmCustomCommand*, std::set<std::string> >
+        CustomCommandAliasMap;
+      typedef Detection::OrderedTargetSet OrderedTargets;
+
+      struct GenerationContext
+      {
+        GenerationContext(cmLocalCommonGenerator* localGen,
+                          FileContext& fileCtx)
+          : root(localGen)
+          , fc(fileCtx)
+        {
+        }
+        cmLocalCommonGenerator* root;
+        FileContext& fc;
+        OrderedTargets orderedTargets;
+        TargetContextList targetContexts;
+      };
+
+      static std::string Join(const std::vector<std::string>& elems,
+                              const std::string& delim);
+
+      struct WrapHelper
+      {
+        std::string m_prefix;
+        std::string m_suffix;
+
+        std::string operator()(const std::string& in)
+        {
+          return m_prefix + in + m_suffix;
+        }
+      };
+
+      static std::string EncodeLiteral(const std::string& lit);
+
+      static void BuildTargetContexts(cmGlobalFastbuildGenerator* gg,
+                                      TargetContextList& map);
+
+      static void GenerateRootBFF(cmGlobalFastbuildGenerator* self);
+
+      static void WritePlaceholders(FileContext& fileContext);
+
+      static void WriteSettings(FileContext& fileContext,
+                                std::string cacheDir);
+
+      struct CompilerDef
+      {
+        std::string name;
+        std::string path;
+        std::string cmakeCompilerID;
+        std::string cmakeCompilerVersion;
+      };
+
+      static bool WriteCompilers(GenerationContext& context);
+
+      static void WriteConfigurations(FileContext& fileContext,
+                                      cmMakefile* makefile);
+
+      struct CompileCommand
+      {
+        std::string defines;
+        std::string flags;
+        std::map<std::string, std::vector<std::string> > sourceFiles;
+      };
+
+      static void WriteTargetDefinitions(GenerationContext& context,
+                                         bool outputGlobals);
+
+      static void WriteAliases(GenerationContext& context,
+                               cmGlobalFastbuildGenerator* gg,
+                               bool outputGlobals);
+    };
+  };
+
+  void ComputeTargetOrderAndDependencies(
+    Detail::Detection::OrderedTargetSet& orderedTargets);
+
+  Detail::FileContext g_fc;
+
+  static const char* FASTBUILD_DOLLAR_TAG;
 
 private:
   class Factory;

--- a/Source/cmGlobalFastbuildGenerator.h
+++ b/Source/cmGlobalFastbuildGenerator.h
@@ -348,7 +348,6 @@ public:
 
 private:
   class Factory;
-  class Detail;
 
   std::vector<std::string> Configurations;
 };

--- a/Source/cmLocalFastbuildGenerator.cxx
+++ b/Source/cmLocalFastbuildGenerator.cxx
@@ -15,7 +15,9 @@
 #include "cmMakefile.h"
 #include "cmSourceFile.h"
 #include "cmSystemTools.h"
+#ifdef _WIN32
 #include "windows.h"
+#endif
 
 //----------------------------------------------------------------------------
 cmLocalFastbuildGenerator::cmLocalFastbuildGenerator()

--- a/Source/cmLocalFastbuildGenerator.cxx
+++ b/Source/cmLocalFastbuildGenerator.cxx
@@ -11,20 +11,22 @@
 ============================================================================*/
 #include "cmLocalFastbuildGenerator.h"
 #include "cmCustomCommandGenerator.h"
+#include "cmGeneratorTarget.h"
 #include "cmGlobalGenerator.h"
 #include "cmMakefile.h"
 #include "cmSourceFile.h"
 #include "cmSystemTools.h"
+
 #ifdef _WIN32
 #include "windows.h"
 #endif
 #define FASTBUILD_DOLLAR_TAG "FASTBUILD_DOLLAR_TAG"
 //----------------------------------------------------------------------------
-cmLocalFastbuildGenerator::cmLocalFastbuildGenerator()
+cmLocalFastbuildGenerator::cmLocalFastbuildGenerator(cmGlobalGenerator* gg,
+                                                     cmMakefile* makefile)
+  : cmLocalCommonGenerator(gg, makefile,
+                           makefile->GetState()->GetBinaryDirectory())
 {
-#ifdef _WIN32
-  this->WindowsShell = true;
-#endif
   this->TargetImplib =
     FASTBUILD_DOLLAR_TAG "TargetOutputImplib" FASTBUILD_DOLLAR_TAG;
   // this->LinkScriptShell = true;
@@ -75,10 +77,10 @@ void cmLocalFastbuildGenerator::ComputeObjectFilenames(
 
 //----------------------------------------------------------------------------
 std::string cmLocalFastbuildGenerator::GetTargetDirectory(
-  cmTarget const& target) const
+  const cmGeneratorTarget* target) const
 {
   std::string dir = cmake::GetCMakeFilesDirectoryPostSlash();
-  dir += target.GetName();
+  dir += target->GetName();
 #if defined(__VMS)
   dir += "_dir";
 #else

--- a/Source/cmLocalFastbuildGenerator.cxx
+++ b/Source/cmLocalFastbuildGenerator.cxx
@@ -1,0 +1,105 @@
+/*============================================================================
+  CMake - Cross Platform Makefile Generator
+  Copyright 2000-2009 Kitware, Inc., Insight Software Consortium
+
+  Distributed under the OSI-approved BSD License (the "License");
+  see accompanying file Copyright.txt for details.
+
+  This software is distributed WITHOUT ANY WARRANTY; without even the
+  implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  See the License for more information.
+============================================================================*/
+#include "cmLocalFastbuildGenerator.h"
+#include "cmCustomCommandGenerator.h"
+#include "cmGlobalGenerator.h"
+#include "cmMakefile.h"
+#include "cmSourceFile.h"
+#include "cmSystemTools.h"
+#include "windows.h"
+
+//----------------------------------------------------------------------------
+cmLocalFastbuildGenerator::cmLocalFastbuildGenerator()
+{
+#ifdef _WIN32
+  this->WindowsShell = true;
+#endif
+  this->TargetImplib = "$TargetOutputImplib$";
+}
+
+//----------------------------------------------------------------------------
+cmLocalFastbuildGenerator::~cmLocalFastbuildGenerator()
+{
+}
+
+//----------------------------------------------------------------------------
+void cmLocalFastbuildGenerator::Generate()
+{
+  // Debug messages
+  // std::cout << "======== LOCAL Fastbuild Gen ========\n";
+  // GetMakefile()->Print();
+
+  // Now generate information for this generator
+}
+
+//----------------------------------------------------------------------------
+void cmLocalFastbuildGenerator::ExpandRuleVariables(
+  std::string& s, const RuleVariables& replaceValues)
+{
+  return cmLocalGenerator::ExpandRuleVariables(s, replaceValues);
+}
+
+//----------------------------------------------------------------------------
+std::string cmLocalFastbuildGenerator::ConvertToLinkReference(
+  std::string const& lib, OutputFormat format)
+{
+  return this->Convert(lib, HOME_OUTPUT, format);
+}
+
+//----------------------------------------------------------------------------
+void cmLocalFastbuildGenerator::ComputeObjectFilenames(
+  std::map<cmSourceFile const*, std::string>& mapping,
+  cmGeneratorTarget const* gt)
+{
+  for (std::map<cmSourceFile const*, std::string>::iterator si =
+         mapping.begin();
+       si != mapping.end(); ++si) {
+    cmSourceFile const* sf = si->first;
+    si->second =
+      this->GetObjectFileNameWithoutTarget(*sf, gt->ObjectDirectory);
+  }
+}
+
+//----------------------------------------------------------------------------
+std::string cmLocalFastbuildGenerator::GetTargetDirectory(
+  cmTarget const& target) const
+{
+  std::string dir = cmake::GetCMakeFilesDirectoryPostSlash();
+  dir += target.GetName();
+#if defined(__VMS)
+  dir += "_dir";
+#else
+  dir += ".dir";
+#endif
+  return dir;
+}
+
+//----------------------------------------------------------------------------
+std::string EncodeLiteral(const std::string& lit)
+{
+  std::string result = lit;
+  cmSystemTools::ReplaceString(result, "$", "^$");
+  return result;
+}
+
+//----------------------------------------------------------------------------
+void cmLocalFastbuildGenerator::AppendFlagEscape(std::string& flags,
+                                                 const std::string& rawFlag)
+{
+  std::string escapedFlag = this->EscapeForShell(rawFlag);
+  // Other make systems will remove the double $ but
+  // fastbuild uses ^$ to escape it. So switch to that.
+  cmSystemTools::ReplaceString(escapedFlag, "$$", "^$");
+  this->AppendFlags(flags, escapedFlag);
+}
+
+//----------------------------------------------------------------------------

--- a/Source/cmLocalFastbuildGenerator.cxx
+++ b/Source/cmLocalFastbuildGenerator.cxx
@@ -18,14 +18,16 @@
 #ifdef _WIN32
 #include "windows.h"
 #endif
-
+#define FASTBUILD_DOLLAR_TAG "FASTBUILD_DOLLAR_TAG"
 //----------------------------------------------------------------------------
 cmLocalFastbuildGenerator::cmLocalFastbuildGenerator()
 {
 #ifdef _WIN32
   this->WindowsShell = true;
 #endif
-  this->TargetImplib = "$TargetOutputImplib$";
+  this->TargetImplib =
+    FASTBUILD_DOLLAR_TAG "TargetOutputImplib" FASTBUILD_DOLLAR_TAG;
+  // this->LinkScriptShell = true;
 }
 
 //----------------------------------------------------------------------------
@@ -54,7 +56,7 @@ void cmLocalFastbuildGenerator::ExpandRuleVariables(
 std::string cmLocalFastbuildGenerator::ConvertToLinkReference(
   std::string const& lib, OutputFormat format)
 {
-  return this->Convert(lib, HOME_OUTPUT, format);
+  return ""; // this->Convert(lib, HOME_OUTPUT, format);
 }
 
 //----------------------------------------------------------------------------
@@ -100,7 +102,7 @@ void cmLocalFastbuildGenerator::AppendFlagEscape(std::string& flags,
   std::string escapedFlag = this->EscapeForShell(rawFlag);
   // Other make systems will remove the double $ but
   // fastbuild uses ^$ to escape it. So switch to that.
-  cmSystemTools::ReplaceString(escapedFlag, "$$", "^$");
+  // cmSystemTools::ReplaceString(escapedFlag, "$$", "^$");
   this->AppendFlags(flags, escapedFlag);
 }
 

--- a/Source/cmLocalFastbuildGenerator.h
+++ b/Source/cmLocalFastbuildGenerator.h
@@ -3,9 +3,9 @@
 #ifndef cmLocalFastbuildGenerator_h
 #define cmLocalFastbuildGenerator_h
 
-#include "cmLocalGenerator.h"
+#include "cmLocalCommonGenerator.h"
 
-#include <cmsys/auto_ptr.hxx>
+#include <cm_auto_ptr.hxx>
 
 class cmSourceFile;
 class cmSourceGroup;
@@ -18,10 +18,10 @@ class cmCustomCommandGenerator;
  * cmLocalFastbuildGenerator provides functionality common to all
  * Visual Studio generators.
  */
-class cmLocalFastbuildGenerator : public cmLocalGenerator
+class cmLocalFastbuildGenerator : public cmLocalCommonGenerator
 {
 public:
-  cmLocalFastbuildGenerator();
+  cmLocalFastbuildGenerator(cmGlobalGenerator* gg, cmMakefile* makefile);
   virtual ~cmLocalFastbuildGenerator();
 
   virtual void Generate();
@@ -32,7 +32,8 @@ public:
   virtual void ComputeObjectFilenames(
     std::map<cmSourceFile const*, std::string>& mapping,
     cmGeneratorTarget const* gt);
-  virtual std::string GetTargetDirectory(cmTarget const& target) const;
+  virtual std::string GetTargetDirectory(
+    cmGeneratorTarget const* target) const;
   virtual void AppendFlagEscape(std::string& flags,
                                 const std::string& rawFlag);
 };

--- a/Source/cmLocalFastbuildGenerator.h
+++ b/Source/cmLocalFastbuildGenerator.h
@@ -1,0 +1,40 @@
+/* Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+   file Copyright.txt or https://cmake.org/licensing for details.  */
+#ifndef cmLocalFastbuildGenerator_h
+#define cmLocalFastbuildGenerator_h
+
+#include "cmLocalGenerator.h"
+
+#include <cmsys/auto_ptr.hxx>
+
+class cmSourceFile;
+class cmSourceGroup;
+class cmCustomCommand;
+class cmCustomCommandGenerator;
+
+/** \class cmLocalFastbuildGenerator
+ * \brief Base class for Visual Studio generators.
+ *
+ * cmLocalFastbuildGenerator provides functionality common to all
+ * Visual Studio generators.
+ */
+class cmLocalFastbuildGenerator : public cmLocalGenerator
+{
+public:
+  cmLocalFastbuildGenerator();
+  virtual ~cmLocalFastbuildGenerator();
+
+  virtual void Generate();
+
+  void ExpandRuleVariables(std::string& s, const RuleVariables& replaceValues);
+  virtual std::string ConvertToLinkReference(std::string const& lib,
+                                             OutputFormat format);
+  virtual void ComputeObjectFilenames(
+    std::map<cmSourceFile const*, std::string>& mapping,
+    cmGeneratorTarget const* gt);
+  virtual std::string GetTargetDirectory(cmTarget const& target) const;
+  virtual void AppendFlagEscape(std::string& flags,
+                                const std::string& rawFlag);
+};
+
+#endif

--- a/Source/cmake.cxx
+++ b/Source/cmake.cxx
@@ -50,6 +50,7 @@
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #if !defined(CMAKE_BOOT_MINGW)
 #include "cmGlobalBorlandMakefileGenerator.h"
+#include "cmGlobalFastbuildGenerator.h"
 #include "cmGlobalGhsMultiGenerator.h"
 #include "cmGlobalJOMMakefileGenerator.h"
 #include "cmGlobalNMakeMakefileGenerator.h"
@@ -1664,6 +1665,7 @@ void cmake::AddDefaultGenerators()
   this->Generators.push_back(cmGlobalNMakeMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalJOMMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalGhsMultiGenerator::NewFactory());
+  this->Generators.push_back(cmGlobalFastbuildGenerator::NewFactory());
 #endif
   this->Generators.push_back(cmGlobalMSYSMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalMinGWMakefileGenerator::NewFactory());

--- a/Source/cmake.cxx
+++ b/Source/cmake.cxx
@@ -77,6 +77,7 @@
 #include "cmGlobalNinjaGenerator.h"
 #endif
 #include "cmExtraCodeLiteGenerator.h"
+#include "cmGlobalFastbuildGenerator.h"
 
 #if !defined(CMAKE_BOOT_MINGW)
 #include "cmExtraCodeBlocksGenerator.h"
@@ -1665,7 +1666,6 @@ void cmake::AddDefaultGenerators()
   this->Generators.push_back(cmGlobalNMakeMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalJOMMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalGhsMultiGenerator::NewFactory());
-  this->Generators.push_back(cmGlobalFastbuildGenerator::NewFactory());
 #endif
   this->Generators.push_back(cmGlobalMSYSMakefileGenerator::NewFactory());
   this->Generators.push_back(cmGlobalMinGWMakefileGenerator::NewFactory());
@@ -1673,6 +1673,7 @@ void cmake::AddDefaultGenerators()
   this->Generators.push_back(cmGlobalUnixMakefileGenerator3::NewFactory());
 #if defined(CMAKE_BUILD_WITH_CMAKE)
   this->Generators.push_back(cmGlobalNinjaGenerator::NewFactory());
+  this->Generators.push_back(cmGlobalFastbuildGenerator::NewFactory());
 #endif
 #if defined(CMAKE_USE_WMAKE)
   this->Generators.push_back(cmGlobalWatcomWMakeGenerator::NewFactory());

--- a/Tests/IncludeDirectories/CMakeLists.txt
+++ b/Tests/IncludeDirectories/CMakeLists.txt
@@ -90,6 +90,6 @@ if (NOT incs STREQUAL ";/one/two")
   message(SEND_ERROR "Empty include_directories entry was not ignored.")
 endif()
 
-if(NOT CMAKE_GENERATOR STREQUAL Xcode AND NOT CMAKE_GENERATOR STREQUAL Ninja)
+if(NOT CMAKE_GENERATOR STREQUAL Xcode AND NOT CMAKE_GENERATOR STREQUAL Ninja AND NOT CMAKE_GENERATOR STREQUAL Fastbuild)
   add_subdirectory(CMP0021)
 endif()

--- a/Tests/Preprocess/CMakeLists.txt
+++ b/Tests/Preprocess/CMakeLists.txt
@@ -31,6 +31,9 @@ endif()
 if("${CMAKE_GENERATOR}" MATCHES "Visual Studio")
   set(PP_VS 1)
 endif()
+if("${CMAKE_GENERATOR}" MATCHES "Fastbuild")
+  set(PP_FBUILD 1)
+endif()
 
 # Some tests below check the PP_* variables set above.  They are meant
 # to test the case that the build tool is at fault.  Other tests below
@@ -59,8 +62,8 @@ endif()
 
 string(APPEND STRING_EXTRA " ")
 
-if(NOT PP_BORLAND AND NOT PP_WATCOM)
-  # Borland, WMake: multiple spaces
+if(NOT PP_BORLAND AND NOT PP_WATCOM AND NOT PP_FBUILD)
+  # Borland, WMake, Fastbuild: multiple spaces
   # The make tool seems to remove extra whitespace from inside
   # quoted strings when passing to the compiler.  It does not have
   # trouble passing to other tools, and the compiler may be directly


### PR DESCRIPTION
Changes:
- a few unused variables removed or commented out
- fixed conditional code for non win32 platforms
- static_cast used to compare signer and unsigned
- removed redundant and mismatching declaration of Detail class

Tested with gcc 5.2.1